### PR TITLE
feat: Add query flags to query commands for all modules

### DIFF
--- a/x/incentives/client/cli/query.go
+++ b/x/incentives/client/cli/query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 
 	"github.com/skip-mev/slinky/x/incentives/types"
@@ -33,7 +34,7 @@ func GetQueryCmd() *cobra.Command {
 // This is essentially a wrapper around the module's QueryClient, as under-the-hood it constructs
 // a request to a query-client served over a grpc-conn embedded in the clientCtx.
 func GetIncentivesByTypeCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "type [type]",
 		Short: "Query for all incentives of a specified type",
 		Args:  cobra.ExactArgs(1),
@@ -61,13 +62,15 @@ func GetIncentivesByTypeCmd() *cobra.Command {
 			return clientCtx.PrintProto(res)
 		},
 	}
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
 }
 
 // GetAllIncentivesCmd returns the cli-command that queries all incentives currently stored in the
 // incentives module. This is essentially a wrapper around the module's QueryClient, as under-the-hood
 // it constructs a request to a query-client served over a grpc-conn embedded in the clientCtx.
 func GetAllIncentivesCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "all-incentives",
 		Short: "Query for all incentives currently stored in the module",
 		Args:  cobra.ExactArgs(0),
@@ -90,4 +93,6 @@ func GetAllIncentivesCmd() *cobra.Command {
 			return clientCtx.PrintProto(res)
 		},
 	}
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
 }

--- a/x/oracle/client/cli/query.go
+++ b/x/oracle/client/cli/query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 
 	"github.com/skip-mev/slinky/x/oracle/types"
@@ -32,7 +33,7 @@ func GetQueryCmd() *cobra.Command {
 // GetPriceCmd returns the cli-command that queries the price information for a given CurrencyPair. This is essentially a wrapper around the module's
 // QueryClient, as under-the-hood it constructs a request to a query-client served over a grpc-conn embedded in the clientCtx.
 func GetPriceCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "price [base] [quote]",
 		Short: "Query for the price of a specified currency-pair",
 		Args:  cobra.ExactArgs(2),
@@ -60,12 +61,14 @@ func GetPriceCmd() *cobra.Command {
 			return clientCtx.PrintProto(res)
 		},
 	}
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
 }
 
 // GetAllCurrencyPairsCmd returns the cli-command that queries for all CurrencyPairs in the module. This is essentially a wrapper around the module's
 // QueryClient, as under-the-hood it constructs a request to a query-client served over a grpc-conn embedded in the clientCtx.
 func GetAllCurrencyPairsCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "currency-pairs",
 		Short: "Query for all the currency-pairs being tracked by the module",
 		Args:  cobra.NoArgs,
@@ -88,4 +91,6 @@ func GetAllCurrencyPairsCmd() *cobra.Command {
 			return clientCtx.PrintProto(res)
 		},
 	}
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
 }

--- a/x/sla/client/cli/query.go
+++ b/x/sla/client/cli/query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 
 	slatypes "github.com/skip-mev/slinky/x/sla/types"
@@ -29,7 +30,7 @@ func GetQueryCmd() *cobra.Command {
 
 // GetAllSLAsCmd returns the cli-command that queries all SLAs in the store.
 func GetAllSLAsCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "slas",
 		Short: "Query for all SLAs in the store",
 		Args:  cobra.NoArgs,
@@ -48,11 +49,13 @@ func GetAllSLAsCmd() *cobra.Command {
 			return clientCtx.PrintProto(resp)
 		},
 	}
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
 }
 
 // GetParams returns the cli-command that queries the current SLA parameters.
 func GetParamsCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "params",
 		Short: "Query for the current SLA parameters",
 		Args:  cobra.NoArgs,
@@ -71,4 +74,6 @@ func GetParamsCmd() *cobra.Command {
 			return clientCtx.PrintProto(resp)
 		},
 	}
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
 }


### PR DESCRIPTION
Resolve #119 

Adds the standard global query flags to all of the modules' query commands.