### PR TITLE
chore: post `marketmap` cleanup

### DIFF
--- a/abci/preblock/oracle/preblock_test.go
+++ b/abci/preblock/oracle/preblock_test.go
@@ -129,7 +129,7 @@ func (s *PreBlockTestSuite) SetupSubTest() {
 	s.handler = preblock.NewOraclePreBlockHandler(
 		log.NewTestLogger(s.T()),
 		aggregationFn,
-		s.oracleKeeper,
+		&s.oracleKeeper,
 		s.mockMetrics,
 		s.cpID,
 		s.veCodec,

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	cosmossdk.io/x/tx v0.13.0
 	cosmossdk.io/x/upgrade v0.1.1
 	github.com/BurntSushi/toml v1.3.2 // indirect
-	github.com/alecthomas/assert/v2 v2.6.0
+	github.com/alecthomas/assert/v2 v2.6.0 // indirect
 	github.com/bits-and-blooms/bitset v1.13.0
 	github.com/client9/misspell v0.3.4
 	github.com/cometbft/cometbft v0.38.5
@@ -82,7 +82,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.0 // indirect
 	github.com/alecthomas/go-check-sumtype v0.1.4 // indirect
-	github.com/alecthomas/repr v0.4.0 // indirect
 	github.com/alexkohler/nakedret/v2 v2.0.2 // indirect
 	github.com/alexkohler/prealloc v1.0.0 // indirect
 	github.com/alingse/asasalint v0.0.11 // indirect

--- a/oracle/config/app_test.go
+++ b/oracle/config/app_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alecthomas/assert/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/skip-mev/slinky/oracle/config"
@@ -139,12 +138,12 @@ func TestReadConfigFromFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create temp file
 			f, err := os.CreateTemp("", "oracle_config")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer os.Remove(f.Name())
 
 			// Write the config as a toml file
 			_, err = f.WriteString(tc.config)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Read config from file
 			_, err = config.ReadConfigFromFile(f.Name())

--- a/oracle/orchestrator/utils_test.go
+++ b/oracle/orchestrator/utils_test.go
@@ -6,6 +6,8 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/skip-mev/slinky/oracle/config"
 	"github.com/skip-mev/slinky/oracle/constants"
 	"github.com/skip-mev/slinky/oracle/orchestrator"
@@ -14,7 +16,6 @@ import (
 	providertypes "github.com/skip-mev/slinky/providers/types"
 	"github.com/skip-mev/slinky/providers/websockets/okx"
 	mmtypes "github.com/skip-mev/slinky/x/marketmap/types"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/pkg/types/currency_pair_test.go
+++ b/pkg/types/currency_pair_test.go
@@ -3,7 +3,7 @@ package types_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 )
@@ -61,9 +61,9 @@ func TestValidateBasic(t *testing.T) {
 			err := tc.cp.ValidateBasic()
 			switch tc.expectPass {
 			case true:
-				assert.Nil(t, err)
+				require.Nil(t, err)
 			default:
-				assert.NotNil(t, err)
+				require.NotNil(t, err)
 			}
 		})
 	}
@@ -101,10 +101,10 @@ func TestToFromString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cp, err := slinkytypes.CurrencyPairFromString(tc.cps)
 			if tc.expectPass {
-				assert.Nil(t, err)
-				assert.Equal(t, cp, tc.cp)
+				require.Nil(t, err)
+				require.Equal(t, cp, tc.cp)
 			} else {
-				assert.NotNil(t, err)
+				require.NotNil(t, err)
 			}
 		})
 	}
@@ -130,7 +130,7 @@ func TestDecimals(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.cp.LegacyDecimals(), tc.dec)
+			require.Equal(t, tc.cp.LegacyDecimals(), tc.dec)
 		})
 	}
 }

--- a/tests/simapp/app.go
+++ b/tests/simapp/app.go
@@ -146,7 +146,7 @@ type SimApp struct {
 	GroupKeeper           groupkeeper.Keeper
 	ConsensusParamsKeeper consensuskeeper.Keeper
 	CircuitBreakerKeeper  circuitkeeper.Keeper
-	OracleKeeper          oraclekeeper.Keeper
+	OracleKeeper          *oraclekeeper.Keeper
 	IncentivesKeeper      incentiveskeeper.Keeper
 	AlertsKeeper          alertskeeper.Keeper
 	MarketMapKeeper       *marketmapkeeper.Keeper
@@ -427,7 +427,7 @@ func NewSimApp(
 	// By default, when using app wiring enabled module, this is not required.
 	// For instance, the upgrade module will set automatically the module version map in its init genesis thanks to app wiring.
 	// However, when registering a module manually (i.e. that does not support app wiring), the module version map
-	// must be set manually as follow. The upgrade module will de-duplicate the module version map.
+	// must be set manually as follows. The upgrade module will de-duplicate the module version map.
 	//
 	// app.SetInitChainer(func(ctx sdk.Context, req *cometabci.RequestInitChain) (*cometabci.ResponseInitChain, error) {
 	// 	req.ConsensusParams.Abci.VoteExtensionsEnableHeight = 2

--- a/x/alerts/types/alert_test.go
+++ b/x/alerts/types/alert_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	"github.com/skip-mev/slinky/x/alerts/types"
@@ -32,14 +32,14 @@ func TestAlertUnmarshal(t *testing.T) {
 
 	// marshal the alert
 	bz, err := cdc.Marshal(&alert)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// unmarshal the alert
 	alert2 := types.Alert{}
-	assert.NoError(t, alert2.Unmarshal(bz))
+	require.NoError(t, alert2.Unmarshal(bz))
 
 	// assert that the two alerts are equal
-	assert.Equal(t, alert, alert2)
+	require.Equal(t, alert, alert2)
 }
 
 func TestAlertValidateBasic(t *testing.T) {
@@ -92,9 +92,9 @@ func TestAlertValidateBasic(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.alert.ValidateBasic()
 			if tc.valid {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 			}
 		})
 	}
@@ -121,20 +121,20 @@ func TestAlertUID(t *testing.T) {
 	}
 	t.Run("test Alert UID uniqueness", func(t *testing.T) {
 		// check that the alerts have different UIDs
-		assert.NotEqual(t, alert1.UID(), alert2.UID())
+		require.NotEqual(t, alert1.UID(), alert2.UID())
 	})
 }
 
 func TestAlertStatus(t *testing.T) {
 	t.Run("test String", func(t *testing.T) {
 		cs := types.ConclusionStatus(0)
-		assert.Equal(t, "Unconcluded", cs.String())
+		require.Equal(t, "Unconcluded", cs.String())
 
 		cs = types.ConclusionStatus(1)
-		assert.Equal(t, "Concluded", cs.String())
+		require.Equal(t, "Concluded", cs.String())
 
 		cs = types.ConclusionStatus(2)
-		assert.Equal(t, "unknown", cs.String())
+		require.Equal(t, "unknown", cs.String())
 	})
 
 	t.Run("test validate basic", func(t *testing.T) {
@@ -175,9 +175,9 @@ func TestAlertStatus(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				err := tc.alertStatus.ValidateBasic()
 				if tc.valid {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				} else {
-					assert.Error(t, err)
+					require.Error(t, err)
 				}
 			})
 		}
@@ -230,9 +230,9 @@ func TestAlertWithStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.alert.ValidateBasic()
 			if tc.valid {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 			}
 		})
 	}

--- a/x/alerts/types/genesis_test.go
+++ b/x/alerts/types/genesis_test.go
@@ -6,7 +6,7 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	"github.com/skip-mev/slinky/x/alerts/types"
@@ -81,12 +81,12 @@ func TestGenesisValidation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.genesis.ValidateBasic()
-			if tc.valid && err != nil {
-				t.Errorf("expected genesis to be valid, got error: %v", err)
+			if tc.valid {
+				require.Nil(t, err)
+				return
 			}
-			if !tc.valid && err == nil {
-				t.Errorf("expected genesis to be invalid, got nil error")
-			}
+
+			require.NotNil(t, err)
 		})
 	}
 }
@@ -94,5 +94,5 @@ func TestGenesisValidation(t *testing.T) {
 func TestDefaultGenesisValidation(t *testing.T) {
 	// test that the default genesis is valid
 	genesis := types.DefaultGenesisState()
-	assert.NoError(t, genesis.ValidateBasic())
+	require.NoError(t, genesis.ValidateBasic())
 }

--- a/x/alerts/types/msgs_test.go
+++ b/x/alerts/types/msgs_test.go
@@ -8,7 +8,7 @@ import (
 	cmtabci "github.com/cometbft/cometbft/abci/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	"github.com/skip-mev/slinky/x/alerts/types"
@@ -57,12 +57,12 @@ func TestMsgAlertGetSigners(t *testing.T) {
 	// create a message with signer
 	msg := types.NewMsgAlert(types.NewAlert(0, signer, slinkytypes.NewCurrencyPair("BTC", "USD")))
 	signers := msg.GetSigners()
-	assert.Equal(t, []sdk.AccAddress{signer}, signers)
+	require.Equal(t, []sdk.AccAddress{signer}, signers)
 }
 
 func TestMsgConclusion(t *testing.T) {
 	invalidConclusionAny, err := codectypes.NewAnyWithValue(&types.MultiSigConclusion{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	validConclusionAny, err := codectypes.NewAnyWithValue(&types.MultiSigConclusion{
 		ExtendedCommitInfo: cmtabci.ExtendedCommitInfo{},
@@ -83,7 +83,7 @@ func TestMsgConclusion(t *testing.T) {
 		},
 		Status: false,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("test validate basic", func(t *testing.T) {
 		cases := []struct {
@@ -146,7 +146,7 @@ func TestMsgConclusion(t *testing.T) {
 		}
 
 		signers := msg.GetSigners()
-		assert.Equal(t, []sdk.AccAddress{signer}, signers)
+		require.Equal(t, []sdk.AccAddress{signer}, signers)
 	})
 }
 

--- a/x/alerts/types/params_test.go
+++ b/x/alerts/types/params_test.go
@@ -7,7 +7,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/skip-mev/slinky/x/alerts/types"
 )
@@ -23,7 +23,7 @@ func TestParamsValidation(t *testing.T) {
 
 	pk := secp256k1.GenPrivKey()
 	pkany, err := codectypes.NewAnyWithValue(pk.PubKey())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cases := []testCase{
 		{
@@ -102,5 +102,5 @@ func TestParamsValidation(t *testing.T) {
 func TestDefaultParamsValidate(t *testing.T) {
 	// test that the default params are valid
 	params := types.DefaultParams("test", nil)
-	assert.NoError(t, params.Validate())
+	require.NoError(t, params.Validate())
 }

--- a/x/alerts/types/strategies/validator_incentive_test.go
+++ b/x/alerts/types/strategies/validator_incentive_test.go
@@ -10,7 +10,6 @@ import (
 	cmtabci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	slinkyabci "github.com/skip-mev/slinky/abci/ve/types"
@@ -96,7 +95,7 @@ func TestValidatorAlertIncentive(t *testing.T) {
 			Power:   1,
 		}, 1, sdk.AccAddress("test"))
 
-		assert.Equal(t, ic.Type(), strategies.ValidatorAlertIncentiveType)
+		require.Equal(t, ic.Type(), strategies.ValidatorAlertIncentiveType)
 	})
 
 	t.Run("test copy", func(t *testing.T) {
@@ -107,8 +106,8 @@ func TestValidatorAlertIncentive(t *testing.T) {
 
 		icCopy := ic.Copy()
 
-		assert.Equal(t, ic, icCopy)
-		assert.False(t, &ic == &icCopy)
+		require.Equal(t, ic, icCopy)
+		require.False(t, &ic == &icCopy)
 
 		// assert addresses are diff
 		addr1 := ic.(*strategies.ValidatorAlertIncentive).Validator.Address
@@ -116,7 +115,7 @@ func TestValidatorAlertIncentive(t *testing.T) {
 
 		addr1[0] = 1
 
-		assert.NotEqual(t, addr1, addr2)
+		require.NotEqual(t, addr1, addr2)
 	})
 }
 

--- a/x/marketmap/keeper/keeper_test.go
+++ b/x/marketmap/keeper/keeper_test.go
@@ -3,9 +3,6 @@ package keeper_test
 import (
 	"testing"
 
-	oraclekeeper "github.com/skip-mev/slinky/x/oracle/keeper"
-	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
-
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/testutil"
@@ -16,6 +13,8 @@ import (
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	"github.com/skip-mev/slinky/x/marketmap/keeper"
 	"github.com/skip-mev/slinky/x/marketmap/types"
+	oraclekeeper "github.com/skip-mev/slinky/x/oracle/keeper"
+	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
 )
 
 type KeeperTestSuite struct {

--- a/x/oracle/keeper/genesis.go
+++ b/x/oracle/keeper/genesis.go
@@ -11,7 +11,7 @@ import (
 
 // InitGenesis initializes the set of CurrencyPairs + their genesis prices (if any) for the x/oracle module.
 // this function panics on any errors, i.e. if the genesis state is invalid, or any state-modifications fail.
-func (k Keeper) InitGenesis(ctx sdk.Context, gs types.GenesisState) {
+func (k *Keeper) InitGenesis(ctx sdk.Context, gs types.GenesisState) {
 	// validate the genesis
 	if err := gs.Validate(); err != nil {
 		panic(err)
@@ -27,12 +27,15 @@ func (k Keeper) InitGenesis(ctx sdk.Context, gs types.GenesisState) {
 	}
 
 	// set the next ID to state
-	k.nextCurrencyPairID.Set(ctx, gs.NextId)
+	err := k.nextCurrencyPairID.Set(ctx, gs.NextId)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // ExportGenesis retrieve all CurrencyPairs + QuotePrices set for the module, and return them as a genesis state.
 // This module panics on any errors encountered in execution.
-func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
+func (k *Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	// get the current next ID
 	id, err := k.nextCurrencyPairID.Peek(ctx)
 	if err != nil {
@@ -46,7 +49,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	}
 
 	// next, iterate over NonceKey to retrieve any CurrencyPairs that have not yet been traversed (CurrencyPairs w/ no Price info)
-	k.IterateCurrencyPairs(ctx, func(cp slinkytypes.CurrencyPair, cps types.CurrencyPairState) {
+	err = k.IterateCurrencyPairs(ctx, func(cp slinkytypes.CurrencyPair, cps types.CurrencyPairState) {
 		// append the currency pair + state to the genesis state
 		gs.CurrencyPairGenesis = append(gs.CurrencyPairGenesis, types.CurrencyPairGenesis{
 			CurrencyPair:      cp,
@@ -55,6 +58,9 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 			CurrencyPairPrice: cps.Price,
 		})
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	return gs
 }

--- a/x/oracle/keeper/genesis_test.go
+++ b/x/oracle/keeper/genesis_test.go
@@ -3,10 +3,9 @@ package keeper_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
 
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	"github.com/skip-mev/slinky/x/oracle/keeper"

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -103,13 +103,13 @@ func NewKeeper(
 	return k
 }
 
-// RemoveCurrencyPair removes a given CurrencyPair from state, i.e removes its nonce + QuotePrice from the module's store.
-func (k Keeper) RemoveCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) {
+// RemoveCurrencyPair removes a given CurrencyPair from state, i.e. removes its nonce + QuotePrice from the module's store.
+func (k *Keeper) RemoveCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) {
 	k.currencyPairs.Remove(ctx, cp.String())
 }
 
 // HasCurrencyPair returns true if a given CurrencyPair is stored in state, false otherwise.
-func (k Keeper) HasCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) bool {
+func (k *Keeper) HasCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) bool {
 	ok, err := k.currencyPairs.Has(ctx, cp.String())
 	if err != nil || !ok {
 		return false
@@ -120,7 +120,7 @@ func (k Keeper) HasCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) bo
 
 // GetPriceWithNonceForCurrencyPair returns a QuotePriceWithNonce for a given CurrencyPair. The nonce for the QuotePrice represents
 // the number of times that a given QuotePrice has been updated. Notice: prefer GetPriceWithNonceForCurrencyPair over GetPriceForCurrencyPair.
-func (k Keeper) GetPriceWithNonceForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) (types.QuotePriceWithNonce, error) {
+func (k *Keeper) GetPriceWithNonceForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) (types.QuotePriceWithNonce, error) {
 	// get the QuotePrice for the currency pair
 	qp, err := k.GetPriceForCurrencyPair(ctx, cp)
 	if err != nil {
@@ -141,12 +141,12 @@ func (k Keeper) GetPriceWithNonceForCurrencyPair(ctx sdk.Context, cp slinkytypes
 }
 
 // NextCurrencyPairID returns the next ID to be assigned to a currency-pair.
-func (k Keeper) NextCurrencyPairID(ctx sdk.Context) (uint64, error) {
+func (k *Keeper) NextCurrencyPairID(ctx sdk.Context) (uint64, error) {
 	return k.nextCurrencyPairID.Peek(ctx)
 }
 
 // GetNonceForCurrencyPair returns the nonce for a given CurrencyPair. If one has not been stored, return an error.
-func (k Keeper) GetNonceForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) (uint64, error) {
+func (k *Keeper) GetNonceForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) (uint64, error) {
 	cps, err := k.currencyPairs.Get(ctx, cp.String())
 	if err != nil {
 		return 0, err
@@ -157,7 +157,7 @@ func (k Keeper) GetNonceForCurrencyPair(ctx sdk.Context, cp slinkytypes.Currency
 
 // GetPriceForCurrencyPair retrieves the QuotePrice for a given CurrencyPair. if a QuotePrice does not
 // exist for the given CurrencyPair, this function errors and returns an empty QuotePrice.
-func (k Keeper) GetPriceForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) (types.QuotePrice, error) {
+func (k *Keeper) GetPriceForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) (types.QuotePrice, error) {
 	cps, err := k.currencyPairs.Get(ctx, cp.String())
 	if err != nil {
 		return types.QuotePrice{}, err
@@ -174,7 +174,7 @@ func (k Keeper) GetPriceForCurrencyPair(ctx sdk.Context, cp slinkytypes.Currency
 // SetPriceForCurrencyPair sets the given QuotePrice for a given CurrencyPair, and updates the CurrencyPair's nonce. Note, no validation is performed on
 // either the CurrencyPair or the QuotePrice (it is expected the caller performs this validation). If the CurrencyPair does not exist, create the currency-pair
 // and set its nonce to 0.
-func (k Keeper) SetPriceForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair, qp types.QuotePrice) error {
+func (k *Keeper) SetPriceForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair, qp types.QuotePrice) error {
 	// get the current state for the currency-pair, fail if it does not exist
 	cps, err := k.currencyPairs.Get(ctx, cp.String())
 	if err != nil {
@@ -197,7 +197,7 @@ func (k Keeper) SetPriceForCurrencyPair(ctx sdk.Context, cp slinkytypes.Currency
 
 // CreateCurrencyPair creates a CurrencyPair in state, and sets its ID to the next available ID. If the CurrencyPair already exists, return an error.
 // the nonce for the CurrencyPair is set to 0.
-func (k Keeper) CreateCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) error {
+func (k *Keeper) CreateCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) error {
 	// check if the currency pair already exists
 	if k.HasCurrencyPair(ctx, cp) {
 		return types.NewCurrencyPairAlreadyExistsError(cp)
@@ -214,7 +214,7 @@ func (k Keeper) CreateCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair)
 
 // GetIDForCurrencyPair returns the ID for a given CurrencyPair. If the CurrencyPair does not exist, return 0, false, if
 // it does, return true and the ID.
-func (k Keeper) GetIDForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) (uint64, bool) {
+func (k *Keeper) GetIDForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair) (uint64, bool) {
 	cps, err := k.currencyPairs.Get(ctx, cp.String())
 	if err != nil {
 		return 0, false
@@ -225,7 +225,7 @@ func (k Keeper) GetIDForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPai
 
 // GetCurrencyPairFromID returns the CurrencyPair for a given ID. If the ID does not exist, return an error and an empty CurrencyPair.
 // Otherwise, return the currency pair and no error.
-func (k Keeper) GetCurrencyPairFromID(ctx sdk.Context, id uint64) (slinkytypes.CurrencyPair, bool) {
+func (k *Keeper) GetCurrencyPairFromID(ctx sdk.Context, id uint64) (slinkytypes.CurrencyPair, bool) {
 	// use the ID index to match the given ID
 	ids, err := k.idIndex.MatchExact(ctx, id)
 	if err != nil {
@@ -251,7 +251,7 @@ func (k Keeper) GetCurrencyPairFromID(ctx sdk.Context, id uint64) (slinkytypes.C
 }
 
 // GetAllCurrencyPairs returns all CurrencyPairs that have currently been stored to state.
-func (k Keeper) GetAllCurrencyPairs(ctx sdk.Context) []slinkytypes.CurrencyPair {
+func (k *Keeper) GetAllCurrencyPairs(ctx sdk.Context) []slinkytypes.CurrencyPair {
 	cps := make([]slinkytypes.CurrencyPair, 0)
 
 	// aggregate CurrencyPairs stored under KeyPrefixNonce
@@ -263,7 +263,7 @@ func (k Keeper) GetAllCurrencyPairs(ctx sdk.Context) []slinkytypes.CurrencyPair 
 }
 
 // IterateCurrencyPairs iterates over all CurrencyPairs in the store, and executes a callback for each CurrencyPair.
-func (k Keeper) IterateCurrencyPairs(ctx sdk.Context, cb func(cp slinkytypes.CurrencyPair, cps types.CurrencyPairState)) error {
+func (k *Keeper) IterateCurrencyPairs(ctx sdk.Context, cb func(cp slinkytypes.CurrencyPair, cps types.CurrencyPairState)) error {
 	it, err := k.currencyPairs.Iterate(ctx, nil)
 	if err != nil {
 		return err

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/skip-mev/slinky/x/oracle/types/mocks"
-
 	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -18,6 +16,7 @@ import (
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	"github.com/skip-mev/slinky/x/oracle/keeper"
 	"github.com/skip-mev/slinky/x/oracle/types"
+	"github.com/skip-mev/slinky/x/oracle/types/mocks"
 )
 
 const (

--- a/x/oracle/keeper/msg_server.go
+++ b/x/oracle/keeper/msg_server.go
@@ -46,7 +46,10 @@ func (m *msgServer) AddCurrencyPairs(goCtx context.Context, req *types.MsgAddCur
 		// only set the currency-pair if it does not already exist in state
 		if !m.k.HasCurrencyPair(ctx, cp) {
 			// set to state, initial nonce will be zero (no price updates have been made for this CurrencyPair)
-			m.k.CreateCurrencyPair(ctx, cp)
+			err := m.k.CreateCurrencyPair(ctx, cp)
+			if err != nil {
+				return nil, fmt.Errorf("error creating currency pair state: %w", err)
+			}
 		}
 	}
 

--- a/x/oracle/keeper/msg_server_test.go
+++ b/x/oracle/keeper/msg_server_test.go
@@ -5,7 +5,7 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	"github.com/skip-mev/slinky/x/oracle/keeper"
@@ -178,15 +178,15 @@ func (s *KeeperTestSuite) TestMsgRemoveCurrencyPairs() {
 	// sanity check, assert existence of cps
 	// cp1
 	qpn, err := s.oracleKeeper.GetPriceWithNonceForCurrencyPair(s.ctx, cp1)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), qpn.Nonce(), uint64(100))
-	assert.Equal(s.T(), qpn.Price.Int64(), int64(100))
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), qpn.Nonce(), uint64(100))
+	require.Equal(s.T(), qpn.Price.Int64(), int64(100))
 
 	// cp2
 	qpn, err = s.oracleKeeper.GetPriceWithNonceForCurrencyPair(s.ctx, cp2)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), qpn.Nonce(), uint64(101))
-	assert.Equal(s.T(), qpn.Price.Int64(), int64(100))
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), qpn.Nonce(), uint64(101))
+	require.Equal(s.T(), qpn.Price.Int64(), int64(100))
 
 	// define test-cases
 	tcs := []struct {
@@ -225,21 +225,21 @@ func (s *KeeperTestSuite) TestMsgRemoveCurrencyPairs() {
 			_, err := ms.RemoveCurrencyPairs(s.ctx, tc.req)
 
 			if !tc.expectPass {
-				assert.NotNil(s.T(), err)
+				require.NotNil(s.T(), err)
 				return
 			}
 
 			// otherwise, assert no error
-			assert.Nil(s.T(), err)
+			require.Nil(s.T(), err)
 
 			// check that all currency-pairs were removed
 			for _, cps := range tc.req.CurrencyPairIds {
 				// get currency pair from request
 				cp, err := slinkytypes.CurrencyPairFromString(cps)
-				assert.Nil(s.T(), err)
+				require.Nil(s.T(), err)
 
 				// assert that currency-pair was removed
-				assert.False(t, s.oracleKeeper.HasCurrencyPair(s.ctx, cp))
+				require.False(t, s.oracleKeeper.HasCurrencyPair(s.ctx, cp))
 			}
 		})
 	}

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -180,7 +180,7 @@ type Inputs struct {
 type Outputs struct {
 	depinject.Out
 
-	OracleKeeper keeper.Keeper
+	OracleKeeper *keeper.Keeper
 	Module       appmodule.AppModule
 	Hooks        marketmaptypes.MarketMapHooksWrapper
 }
@@ -202,7 +202,7 @@ func ProvideModule(in Inputs) Outputs {
 	m := NewAppModule(in.Cdc, oracleKeeper)
 
 	return Outputs{
-		OracleKeeper: oracleKeeper,
+		OracleKeeper: &oracleKeeper,
 		Module:       m,
 		Hooks:        marketmaptypes.MarketMapHooksWrapper{MarketMapHooks: oracleKeeper.Hooks()},
 	}

--- a/x/oracle/types/currency_pair_state.go
+++ b/x/oracle/types/currency_pair_state.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 )
 
-// NewCurrencyPairState returns a new CurrencyPairState given an Id, nonce, and QuotePrice.
-func NewCurrencyPairState(id uint64, nonce uint64, quotePrice *QuotePrice) CurrencyPairState {
+// NewCurrencyPairState returns a new CurrencyPairState given an ID, nonce, and QuotePrice.
+func NewCurrencyPairState(id, nonce uint64, quotePrice *QuotePrice) CurrencyPairState {
 	return CurrencyPairState{
 		Id:    id,
 		Nonce: nonce,
@@ -13,7 +13,7 @@ func NewCurrencyPairState(id uint64, nonce uint64, quotePrice *QuotePrice) Curre
 	}
 }
 
-// ValidateBasic checks that the CurrencyPairState is valid, i.e the nonce is zero if the QuotePrice is nil, and non-zero
+// ValidateBasic checks that the CurrencyPairState is valid, i.e. the nonce is zero if the QuotePrice is nil, and non-zero
 // otherwise.
 func (cps *CurrencyPairState) ValidateBasic() error {
 	// check that the nonce is zero if the QuotePrice is nil

--- a/x/oracle/types/currency_pair_state_test.go
+++ b/x/oracle/types/currency_pair_state_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"cosmossdk.io/math"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/skip-mev/slinky/x/oracle/types"
 )
@@ -55,7 +55,7 @@ func TestCurrencyPairState(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.cps.ValidateBasic() == nil, tc.valid)
+			require.Equal(t, tc.cps.ValidateBasic() == nil, tc.valid)
 		})
 	}
 }

--- a/x/oracle/types/genesis_test.go
+++ b/x/oracle/types/genesis_test.go
@@ -3,9 +3,9 @@ package types_test
 import (
 	"testing"
 
-	slinkytypes "github.com/skip-mev/slinky/pkg/types"
+	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 
 	"github.com/skip-mev/slinky/x/oracle/types"
 )
@@ -122,9 +122,9 @@ func TestGenesisValidation(t *testing.T) {
 			err := gs.Validate()
 
 			if tc.expectPass {
-				assert.Nil(t, err)
+				require.Nil(t, err)
 			} else {
-				assert.NotNil(t, err)
+				require.NotNil(t, err)
 			}
 		})
 	}

--- a/x/oracle/types/msgs.go
+++ b/x/oracle/types/msgs.go
@@ -21,7 +21,7 @@ func NewMsgAddCurrencyPairs(authority string, cps []slinkytypes.CurrencyPair) Ms
 
 // GetSigners get the addresses that must sign this message. In this case, the signer
 // must be the module authority.
-func (m MsgAddCurrencyPairs) GetSigners() []sdk.AccAddress {
+func (m *MsgAddCurrencyPairs) GetSigners() []sdk.AccAddress {
 	// convert from string to acc address
 	addr, _ := sdk.AccAddressFromBech32(m.Authority)
 	return []sdk.AccAddress{addr}
@@ -30,7 +30,7 @@ func (m MsgAddCurrencyPairs) GetSigners() []sdk.AccAddress {
 // ValidateBasic determines whether the information in the message is formatted correctly, specifically
 // whether the authority is a valid acc-address, and that each CurrencyPair in the message is formatted correctly.
 
-func (m MsgAddCurrencyPairs) ValidateBasic() error {
+func (m *MsgAddCurrencyPairs) ValidateBasic() error {
 	// validate authority address
 	_, err := sdk.AccAddressFromBech32(m.Authority)
 	if err != nil {
@@ -57,7 +57,7 @@ func NewMsgRemoveCurrencyPairs(authority string, currencyPairIDs []string) MsgRe
 
 // GetSigners gets the addresses that must sign this message. In this case, the signer
 // must be the module authority.
-func (m MsgRemoveCurrencyPairs) GetSigners() []sdk.AccAddress {
+func (m *MsgRemoveCurrencyPairs) GetSigners() []sdk.AccAddress {
 	// convert from string to acc address
 	addr, _ := sdk.AccAddressFromBech32(m.Authority)
 	return []sdk.AccAddress{addr}
@@ -65,7 +65,7 @@ func (m MsgRemoveCurrencyPairs) GetSigners() []sdk.AccAddress {
 
 // ValidateBasic determines whether the information in the message is valid, specifically
 // whether the authority is a valid acc-address, and that each CurrencyPairID in the message is formatted correctly.
-func (m MsgRemoveCurrencyPairs) ValidateBasic() error {
+func (m *MsgRemoveCurrencyPairs) ValidateBasic() error {
 	// validate authority address
 	_, err := sdk.AccAddressFromBech32(m.Authority)
 	if err != nil {

--- a/x/oracle/types/msgs_test.go
+++ b/x/oracle/types/msgs_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
 	"github.com/skip-mev/slinky/x/oracle/types"
@@ -16,7 +16,7 @@ func TestGetSignersMsgAddCurrencyPairs(t *testing.T) {
 	msg := types.NewMsgAddCurrencyPairs(auth, nil)
 	// get signers
 	signer := msg.GetSigners()
-	assert.Equal(t, signer[0].String(), auth)
+	require.Equal(t, signer[0].String(), auth)
 }
 
 func TestGetSignersMsgRemoveCurrencyPairs(t *testing.T) {
@@ -25,7 +25,7 @@ func TestGetSignersMsgRemoveCurrencyPairs(t *testing.T) {
 	msg := types.NewMsgRemoveCurrencyPairs(auth, nil)
 	// get signers
 	signer := msg.GetSigners()
-	assert.Equal(t, signer[0].String(), auth)
+	require.Equal(t, signer[0].String(), auth)
 }
 
 func TestValidateBasicMsgAddCurrencyPairs(t *testing.T) {
@@ -68,9 +68,9 @@ func TestValidateBasicMsgAddCurrencyPairs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
 			if !tc.expectPass {
-				assert.NotNil(t, err)
+				require.NotNil(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.Nil(t, err)
 			}
 		})
 	}
@@ -116,9 +116,9 @@ func TestValidateBasicMsgRemoveCurrencyPairs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
 			if !tc.expectPass {
-				assert.NotNil(t, err)
+				require.NotNil(t, err)
 			} else {
-				assert.Nil(t, err)
+				require.Nil(t, err)
 			}
 		})
 	}

--- a/x/oracle/types/quote_price.go
+++ b/x/oracle/types/quote_price.go
@@ -25,7 +25,7 @@ func (q *QuotePriceWithNonce) Nonce() uint64 {
 }
 
 // ValidateBasic validates that the QuotePrice is valid, i.e. that the price is non-negative.
-func (qp QuotePrice) ValidateBasic() error {
+func (qp *QuotePrice) ValidateBasic() error {
 	// Check that the price is non-negative
 	if qp.Price.IsNegative() {
 		return fmt.Errorf("price cannot be negative: %s", qp.Price)
@@ -35,6 +35,6 @@ func (qp QuotePrice) ValidateBasic() error {
 }
 
 // ValidateBasic validates that the QuotePriceWithNonce is valid, i.e that the underlying QuotePrice is valid.
-func (q QuotePriceWithNonce) ValidateBasic() error {
+func (q *QuotePriceWithNonce) ValidateBasic() error {
 	return q.QuotePrice.ValidateBasic()
 }


### PR DESCRIPTION
move from `assert` to `require`.  `require` causes the tests to fail immediately instead of `assert` which is more desired.