### PR TITLE
fix: Make `VerifyVoteExtension` stateless [BLO-945]

### DIFF
--- a/abci/proposals/proposals.go
+++ b/abci/proposals/proposals.go
@@ -13,7 +13,6 @@ import (
 	slinkyabci "github.com/skip-mev/slinky/abci/types"
 
 	"github.com/skip-mev/slinky/abci/strategies/codec"
-	"github.com/skip-mev/slinky/abci/strategies/currencypair"
 	"github.com/skip-mev/slinky/abci/ve"
 )
 
@@ -46,10 +45,6 @@ type ProposalHandler struct {
 	// extendedCommitCodec is used to decode extended commit info.
 	extendedCommitCodec codec.ExtendedCommitCodec
 
-	// currencyPairStrategy is the strategy used to determine the price information
-	// from a given oracle vote extension.
-	currencyPairStrategy currencypair.CurrencyPairStrategy
-
 	// metrics is responsible for reporting / aggregating consensus-specific
 	// metrics for this validator.
 	metrics servicemetrics.Metrics
@@ -68,7 +63,6 @@ func NewProposalHandler(
 	validateVoteExtensionsFn ve.ValidateVoteExtensionsFn,
 	voteExtensionCodec codec.VoteExtensionCodec,
 	extendedCommitInfoCodec codec.ExtendedCommitCodec,
-	currencyPairStrategy currencypair.CurrencyPairStrategy,
 	metrics servicemetrics.Metrics,
 	opts ...Option,
 ) *ProposalHandler {
@@ -79,7 +73,6 @@ func NewProposalHandler(
 		validateVoteExtensionsFn: validateVoteExtensionsFn,
 		voteExtensionCodec:       voteExtensionCodec,
 		extendedCommitCodec:      extendedCommitInfoCodec,
-		currencyPairStrategy:     currencyPairStrategy,
 		metrics:                  metrics,
 	}
 

--- a/abci/proposals/validate.go
+++ b/abci/proposals/validate.go
@@ -44,7 +44,7 @@ func (h *ProposalHandler) ValidateExtendedCommitInfo(
 		}
 
 		// The vote extension are from the previous block.
-		if err := ve.ValidateOracleVoteExtension(ctx, voteExt, h.currencyPairStrategy); err != nil {
+		if err := ve.ValidateOracleVoteExtension(voteExt, h.currencyPairStrategy); err != nil {
 			h.logger.Error(
 				"failed to validate oracle vote extension",
 				"height", height,

--- a/abci/proposals/validate.go
+++ b/abci/proposals/validate.go
@@ -44,7 +44,7 @@ func (h *ProposalHandler) ValidateExtendedCommitInfo(
 		}
 
 		// The vote extension are from the previous block.
-		if err := ve.ValidateOracleVoteExtension(voteExt, h.currencyPairStrategy); err != nil {
+		if err := ve.ValidateOracleVoteExtension(voteExt); err != nil {
 			h.logger.Error(
 				"failed to validate oracle vote extension",
 				"height", height,

--- a/abci/ve/utils.go
+++ b/abci/ve/utils.go
@@ -14,26 +14,14 @@ import (
 
 // ValidateOracleVoteExtension validates the vote extension provided by a validator.
 func ValidateOracleVoteExtension(
-	ctx sdk.Context,
 	ve vetypes.OracleVoteExtension,
 	strategy currencypair.CurrencyPairStrategy,
 ) error {
 	// Verify prices are valid.
-	for id, bz := range ve.Prices {
+	for _, bz := range ve.Prices {
 		// Ensure that the price bytes are not too long.
 		if len(bz) > slinkyabci.MaximumPriceSize {
 			return fmt.Errorf("price bytes are too long: %d", len(bz))
-		}
-
-		// Ensure that the currency pair ID is valid.
-		cp, err := strategy.FromID(ctx, id)
-		if err != nil {
-			return fmt.Errorf("invalid currency pair ID: %d", id)
-		}
-
-		// Ensure that the price bytes are valid.
-		if _, err := strategy.GetDecodedPrice(ctx, cp, bz); err != nil {
-			return fmt.Errorf("invalid price bytes: %w", err)
 		}
 	}
 

--- a/abci/ve/utils.go
+++ b/abci/ve/utils.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/skip-mev/slinky/abci/strategies/currencypair"
 	slinkyabci "github.com/skip-mev/slinky/abci/types"
 	vetypes "github.com/skip-mev/slinky/abci/ve/types"
 )
@@ -15,7 +14,6 @@ import (
 // ValidateOracleVoteExtension validates the vote extension provided by a validator.
 func ValidateOracleVoteExtension(
 	ve vetypes.OracleVoteExtension,
-	strategy currencypair.CurrencyPairStrategy,
 ) error {
 	// Verify prices are valid.
 	for _, bz := range ve.Prices {

--- a/abci/ve/vote_extension.go
+++ b/abci/ve/vote_extension.go
@@ -247,7 +247,7 @@ func (h *VoteExtensionHandler) VerifyVoteExtensionHandler() sdk.VerifyVoteExtens
 			return &cometabci.ResponseVerifyVoteExtension{Status: cometabci.ResponseVerifyVoteExtension_REJECT}, err
 		}
 
-		if err := ValidateOracleVoteExtension(ctx, voteExtension, h.currencyPairStrategy); err != nil {
+		if err := ValidateOracleVoteExtension(voteExtension, h.currencyPairStrategy); err != nil {
 			h.logger.Error(
 				"failed to validate vote extension",
 				"height", req.Height,

--- a/abci/ve/vote_extension.go
+++ b/abci/ve/vote_extension.go
@@ -247,7 +247,7 @@ func (h *VoteExtensionHandler) VerifyVoteExtensionHandler() sdk.VerifyVoteExtens
 			return &cometabci.ResponseVerifyVoteExtension{Status: cometabci.ResponseVerifyVoteExtension_REJECT}, err
 		}
 
-		if err := ValidateOracleVoteExtension(voteExtension, h.currencyPairStrategy); err != nil {
+		if err := ValidateOracleVoteExtension(voteExtension); err != nil {
 			h.logger.Error(
 				"failed to validate vote extension",
 				"height", req.Height,

--- a/abci/ve/vote_extension_test.go
+++ b/abci/ve/vote_extension_test.go
@@ -384,81 +384,12 @@ func (s *VoteExtensionTestSuite) TestVerifyVoteExtension() {
 				}
 			},
 			currencyPairStrategy: func() *mockstrategies.CurrencyPairStrategy {
-				cpStrategy := mockstrategies.NewCurrencyPairStrategy(s.T())
-
-				cpStrategy.On("FromID", mock.Anything, uint64(0)).Return(btcUSD, nil)
-				cpStrategy.On("GetDecodedPrice", mock.Anything, btcUSD, oneHundred.Bytes()).Return(oneHundred, nil)
-
-				cpStrategy.On("FromID", mock.Anything, uint64(1)).Return(ethUSD, nil)
-				cpStrategy.On("GetDecodedPrice", mock.Anything, ethUSD, twoHundred.Bytes()).Return(twoHundred, nil)
-
-				return cpStrategy
+				return mockstrategies.NewCurrencyPairStrategy(s.T())
 			},
 			expectedResponse: &cometabci.ResponseVerifyVoteExtension{
 				Status: cometabci.ResponseVerifyVoteExtension_ACCEPT,
 			},
 			expectedError: false,
-		},
-		{
-			name: "invalid vote extension with bad id",
-			getReq: func() *cometabci.RequestVerifyVoteExtension {
-				prices := map[uint64][]byte{
-					0: oneHundred.Bytes(),
-				}
-
-				ve, err := testutils.CreateVoteExtensionBytes(
-					prices,
-					codec,
-				)
-				s.Require().NoError(err)
-
-				return &cometabci.RequestVerifyVoteExtension{
-					VoteExtension: ve,
-					Height:        1,
-				}
-			},
-			currencyPairStrategy: func() *mockstrategies.CurrencyPairStrategy {
-				cpStrategy := mockstrategies.NewCurrencyPairStrategy(s.T())
-
-				cpStrategy.On("FromID", mock.Anything, uint64(0)).Return(btcUSD, fmt.Errorf("error"))
-
-				return cpStrategy
-			},
-			expectedResponse: &cometabci.ResponseVerifyVoteExtension{
-				Status: cometabci.ResponseVerifyVoteExtension_REJECT,
-			},
-			expectedError: true,
-		},
-		{
-			name: "invalid vote extension with bad price",
-			getReq: func() *cometabci.RequestVerifyVoteExtension {
-				prices := map[uint64][]byte{
-					0: oneHundred.Bytes(),
-				}
-
-				ve, err := testutils.CreateVoteExtensionBytes(
-					prices,
-					codec,
-				)
-				s.Require().NoError(err)
-
-				return &cometabci.RequestVerifyVoteExtension{
-					VoteExtension: ve,
-					Height:        1,
-				}
-			},
-			currencyPairStrategy: func() *mockstrategies.CurrencyPairStrategy {
-				cpStrategy := mockstrategies.NewCurrencyPairStrategy(s.T())
-
-				cpStrategy.On("FromID", mock.Anything, uint64(0)).Return(btcUSD, nil)
-				cpStrategy.On("GetDecodedPrice", mock.Anything, btcUSD, oneHundred.Bytes()).Return(nil, fmt.Errorf("error"))
-
-				return cpStrategy
-			},
-			expectedResponse: &cometabci.ResponseVerifyVoteExtension{
-				Status: cometabci.ResponseVerifyVoteExtension_REJECT,
-			},
-			expectedError: true,
 		},
 		{
 			name: "vote extension with no prices",

--- a/tests/simapp/app.go
+++ b/tests/simapp/app.go
@@ -353,7 +353,6 @@ func NewSimApp(
 			compression.NewDefaultExtendedCommitCodec(),
 			compression.NewZStdCompressor(),
 		),
-		currencypair.NewDeltaCurrencyPairStrategy(app.OracleKeeper),
 		oracleMetrics,
 	)
 	app.SetPrepareProposal(proposalHandler.PrepareProposalHandler())


### PR DESCRIPTION
## In This PR
- I remove stateful validation from `VerifyVoteExtension`, this is necessary as votes are extended against block `h` (we optimistically apply proposals in `ExtendVote`), while we are only able to verify against `h - 1` state.