### PR TITLE
chore: ignore `mocks` for codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*.bak
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/Makefile
+++ b/Makefile
@@ -176,10 +176,11 @@ test-bench: tidy
 test-cover: tidy
 	@echo Running unit tests and creating coverage report...
 	@go test -mod=readonly -v -timeout 30m -coverprofile=$(COVER_FILE) -covermode=atomic $(shell go list ./... | grep -v tests/)
-	@sed -i '/.pb.go/d' $(COVER_FILE)
-	@sed -i '/.pulsar.go/d' $(COVER_FILE)
-	@sed -i '/.proto/d' $(COVER_FILE)
-	@sed -i '/.pb.gw.go/d' $(COVER_FILE)
+	@sed -i'.bak' -e '/.pb.go/d' $(COVER_FILE)
+	@sed -i'.bak' -e '/.pulsar.go/d' $(COVER_FILE)
+	@sed -i'.bak' -e '/.proto/d' $(COVER_FILE)
+	@sed -i'.bak' -e '/.pb.gw.go/d' $(COVER_FILE)
+	@sed -i'.bak' -e '/mocks/d' $(COVER_FILE)
 
 .PHONY: test test-e2e test-petri-integ
 


### PR DESCRIPTION
- improve accuracy of our codecov by reducing noise from the any generated mocks
- ensure `make test-cover` is able to run on macOS (using BSD var of `sed`)