### PR TITLE
chore: Convert all commands to cobra

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -18,65 +18,89 @@ import (
 )
 
 var (
-	host = flag.String("host", "localhost", "host for the grpc-service to listen on")
-	port = flag.String("port", "8080", "port for the grpc-service to listen on")
+	rootCmd = &cobra.Command{
+		Use:   "client",
+		Short: "Continuously calls the Prices RPC on the sidecar.",
+		Args:  cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			// Channel with width for termination signal.
+			sigs := make(chan os.Signal, 1)
+
+			// Gracefully trigger close on interrupt or terminate signals.
+			signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+			// Set up a connection to the server.
+			url := fmt.Sprintf("%s:%s", host, port)
+			conn, err := grpc.Dial(url, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+			if err != nil {
+				log.Fatalf("did not connect: %v", err)
+			}
+			defer conn.Close()
+
+			// Create a new client
+			client := types.NewOracleClient(conn)
+
+			// Continuous loop
+			for {
+				select {
+				case <-sigs:
+					log.Printf("Received interrupt or terminate signal, exiting...\n")
+					return
+				default:
+					// Call Prices RPC
+					log.Printf("Calling Prices RPC...\n")
+					resp, err := client.Prices(context.Background(), &types.QueryPricesRequest{})
+					if err != nil {
+						log.Fatalf("could not get prices: %v", err) //nolint
+					}
+
+					prices := resp.GetPrices()
+
+					var keys []string
+					for k := range prices {
+						keys = append(keys, k)
+					}
+
+					// Sort the prices by the currency pair
+					sort.Slice(keys, func(i, j int) bool {
+						return keys[i] < keys[j]
+					})
+
+					// Log the response
+					for _, key := range keys {
+						log.Printf("Currency Pair, Price: (%s, %s)", key, prices[key])
+					}
+
+					// Wait for a bit before making the next request
+					log.Printf("Sleeping for 10 seconds...\n\n")
+					time.Sleep(time.Second * 10) // Adjust the interval as needed
+				}
+			}
+		},
+	}
+	// host stores the host portion of the sidecar RPC to query
+	host string
+	// port stores the port of the sidecar RPC to query
+	port string
 )
 
+func init() {
+	rootCmd.Flags().StringVarP(
+		&host,
+		"host",
+		"",
+		"localhost",
+		"host of the grpc-service, which the client will connect to",
+	)
+	rootCmd.Flags().StringVarP(
+		&port,
+		"port",
+		"",
+		"8080",
+		"port the grpc-service, which the client will connect to",
+	)
+}
+
 func main() {
-	// Channel with width for termination signal.
-	sigs := make(chan os.Signal, 1)
-
-	// Gracefully trigger close on interrupt or terminate signals.
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
-	// Parse flags.
-	flag.Parse()
-
-	// Set up a connection to the server.
-	url := fmt.Sprintf("%s:%s", *host, *port)
-	conn, err := grpc.Dial(url, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-	if err != nil {
-		log.Fatalf("did not connect: %v", err)
-	}
-	defer conn.Close()
-
-	// Create a new client
-	client := types.NewOracleClient(conn)
-
-	// Continuous loop
-	for {
-		select {
-		case <-sigs:
-			log.Printf("Received interrupt or terminate signal, exiting...\n")
-			return
-		default:
-			// Call Prices RPC
-			log.Printf("Calling Prices RPC...\n")
-			resp, err := client.Prices(context.Background(), &types.QueryPricesRequest{})
-			if err != nil {
-				log.Fatalf("could not get prices: %v", err) //nolint
-			}
-
-			prices := resp.GetPrices()
-
-			var keys []string
-			for k := range prices {
-				keys = append(keys, k)
-			}
-
-			// Sort the prices by the currency pair
-			sort.Slice(keys, func(i, j int) bool {
-				return keys[i] < keys[j]
-			})
-
-			// Log the response
-			for _, key := range keys {
-				log.Printf("Currency Pair, Price: (%s, %s)", key, prices[key])
-			}
-
-			// Wait for a bit before making the next request
-			log.Printf("Sleeping for 10 seconds...\n\n")
-			time.Sleep(time.Second * 10) // Adjust the interval as needed
-		}
-	}
+	rootCmd.Execute()
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -51,7 +51,7 @@ var (
 					log.Printf("Calling Prices RPC...\n")
 					resp, err := client.Prices(context.Background(), &types.QueryPricesRequest{})
 					if err != nil {
-						log.Fatalf("could not get prices: %v", err) //nolint
+						log.Fatalf("could not get prices: %v", err)
 					}
 
 					prices := resp.GetPrices()
@@ -78,9 +78,9 @@ var (
 			}
 		},
 	}
-	// host stores the host portion of the sidecar RPC to query
+	// host stores the host portion of the sidecar RPC to query.
 	host string
-	// port stores the port of the sidecar RPC to query
+	// port stores the port of the sidecar RPC to query.
 	port string
 )
 

--- a/cmd/oracle/main.go
+++ b/cmd/oracle/main.go
@@ -105,24 +105,24 @@ func runOracle() error {
 
 	cfg, err := config.ReadOracleConfigFromFile(oracleCfgPath)
 	if err != nil {
-		return fmt.Errorf("failed to read oracle config file: %s\n", err.Error())
+		return fmt.Errorf("failed to read oracle config file: %s", err.Error())
 	}
 
 	marketCfg, err := types.ReadMarketConfigFromFile(marketCfgPath)
 	if err != nil {
-		return fmt.Errorf("failed to read market config file: %s\n", err.Error())
+		return fmt.Errorf("failed to read market config file: %s", err.Error())
 	}
 
 	var logger *zap.Logger
 	if !cfg.Production {
 		logger, err = zap.NewDevelopment()
 		if err != nil {
-			return fmt.Errorf("failed to create logger: %s\n", err.Error())
+			return fmt.Errorf("failed to create logger: %s", err.Error())
 		}
 	} else {
 		logger, err = zap.NewProduction()
 		if err != nil {
-			return fmt.Errorf("failed to create logger: %s\n", err.Error())
+			return fmt.Errorf("failed to create logger: %s", err.Error())
 		}
 	}
 
@@ -143,7 +143,7 @@ func runOracle() error {
 	if chain == constants.DYDXMainnet.ID || chain == constants.DYDXTestnet.ID {
 		customOrchestratorOps, customOracleOpts, err := dydxOptions(logger, marketCfg)
 		if err != nil {
-			return fmt.Errorf("failed to create dydx orchestrator and oracle options", zap.Error(err))
+			return fmt.Errorf("failed to create dydx orchestrator and oracle options: %w", err)
 		}
 
 		orchestratorOpts = append(orchestratorOpts, customOrchestratorOps...)
@@ -156,11 +156,11 @@ func runOracle() error {
 		orchestratorOpts...,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create provider orchestrator", zap.Error(err))
+		return fmt.Errorf("failed to create provider orchestrator: %w", err)
 	}
 
 	if err := orch.Start(ctx); err != nil {
-		return fmt.Errorf("failed to start provider orchestrator", zap.Error(err))
+		return fmt.Errorf("failed to start provider orchestrator: %w", err)
 	}
 	defer orch.Stop()
 
@@ -168,7 +168,7 @@ func runOracle() error {
 	oracleOpts = append(oracleOpts, oracle.WithProviders(orch.GetPriceProviders()))
 	orc, err := oracle.New(oracleOpts...)
 	if err != nil {
-		return fmt.Errorf("failed to create oracle", zap.Error(err))
+		return fmt.Errorf("failed to create oracle: %w", err)
 	}
 	srv := oracleserver.NewOracleServer(orc, logger)
 
@@ -185,7 +185,7 @@ func runOracle() error {
 		logger.Info("starting prometheus metrics", zap.String("address", cfg.Metrics.PrometheusServerAddress))
 		ps, err := promserver.NewPrometheusServer(cfg.Metrics.PrometheusServerAddress, logger)
 		if err != nil {
-			return fmt.Errorf("failed to start prometheus metrics", zap.Error(err))
+			return fmt.Errorf("failed to start prometheus metrics: %w", err)
 		}
 
 		go ps.Start()


### PR DESCRIPTION
Converts the rest of our commands to cobra commands.

I haven't done any cleanup of behavior in terms of required flags or anything else--just a straight port of the existing CLI tools.

`make run-oracle-server`, `make run-oracle-client` works.