### PR TITLE
feat(providers/api): Introduce a `APIPriceFetcher` interface [BLO-1026] [BLO-1047]

### DIFF
--- a/providers/base/api/handlers/api_query_handler.go
+++ b/providers/base/api/handlers/api_query_handler.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -13,7 +12,6 @@ import (
 
 	"github.com/skip-mev/slinky/oracle/config"
 	"github.com/skip-mev/slinky/pkg/math"
-	"github.com/skip-mev/slinky/providers/base/api/errors"
 	"github.com/skip-mev/slinky/providers/base/api/metrics"
 	providertypes "github.com/skip-mev/slinky/providers/types"
 )
@@ -32,6 +30,18 @@ type APIQueryHandler[K providertypes.ResponseKey, V providertypes.ResponseValue]
 	)
 }
 
+// APIPriceFetcher is an interface that encapsulates fetching prices from a provider. This interface
+// is meant to abstract over the various processes of interacting w/ GRPC, JSON-RPC, REST, etc. APIs.
+type APIPriceFetcher[K providertypes.ResponseKey, V providertypes.ResponseValue] interface {
+	// FetchPrices fetches prices from the API for the given IDs. The response is returned
+	// as a map of IDs to their respective prices. The request should respect the context timeout
+	// and cancel the request if the context is cancelled.
+	FetchPrices(
+		ctx context.Context,
+		ids []K,
+	) (providertypes.GetResponse[K, V])
+}
+
 // APIQueryHandlerImpl is the default API implementation of the QueryHandler interface.
 // This is used to query using http requests. It manages querying the data provider
 // by using the APIDataHandler and RequestHandler. All responses are sent to the
@@ -43,13 +53,8 @@ type APIQueryHandlerImpl[K providertypes.ResponseKey, V providertypes.ResponseVa
 	metrics metrics.APIMetrics
 	config  config.APIConfig
 
-	// The request handler is responsible for making outgoing HTTP requests with
-	// a given URL. This can be the default client or a custom client.
-	requestHandler RequestHandler
-
-	// The API data handler is responsible for creating the URL to be sent to the
-	// request handler and parsing the response from the request handler.
-	apiHandler APIDataHandler[K, V]
+	// priceFetcher is responsible for fetching prices from the API.
+	priceFetcher APIPriceFetcher[K, V]
 }
 
 // NewAPIQueryHandler creates a new APIQueryHandler. It manages querying the data
@@ -73,24 +78,20 @@ func NewAPIQueryHandler[K providertypes.ResponseKey, V providertypes.ResponseVal
 		return nil, fmt.Errorf("no logger specified for api query handler")
 	}
 
-	if requestHandler == nil {
-		return nil, fmt.Errorf("no request handler specified for api query handler")
-	}
-
-	if apiHandler == nil {
-		return nil, fmt.Errorf("no api data handler specified for api query handler")
-	}
-
 	if metrics == nil {
 		return nil, fmt.Errorf("no metrics specified for api query handler")
+	}
+
+	priceFetcher, err := NewRestAPIPriceFetcher(requestHandler, apiHandler, metrics, cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create price fetcher: %w", err)
 	}
 
 	return &APIQueryHandlerImpl[K, V]{
 		logger:         logger.With(zap.String("api_data_handler", cfg.Name)),
 		config:         cfg,
-		requestHandler: requestHandler,
-		apiHandler:     apiHandler,
 		metrics:        metrics,
+		priceFetcher:   priceFetcher,
 	}, nil
 }
 
@@ -174,11 +175,7 @@ func (h *APIQueryHandlerImpl[K, V]) subTask(
 	responseCh chan<- providertypes.GetResponse[K, V],
 ) func() error {
 	return func() error {
-		var (
-			start = time.Now().UTC()
-			resp  *http.Response
-			err   error
-		)
+		start := time.Now().UTC()
 
 		defer func() {
 			// Recover from any panics that occur.
@@ -187,74 +184,12 @@ func (h *APIQueryHandlerImpl[K, V]) subTask(
 			}
 
 			h.metrics.ObserveProviderResponseLatency(h.config.Name, time.Since(start))
-			h.metrics.AddHTTPStatusCode(h.config.Name, resp)
 			h.logger.Debug("finished subtask", zap.Any("ids", ids))
 		}()
 
 		h.logger.Debug("starting subtask", zap.Any("ids", ids))
 
-		// Create the URL for the request.
-		url, err := h.apiHandler.CreateURL(ids)
-		if err != nil {
-			h.writeResponse(ctx, responseCh, providertypes.NewGetResponseWithErr[K, V](
-				ids,
-				providertypes.NewErrorWithCode(
-					errors.ErrCreateURLWithErr(err),
-					providertypes.ErrorUnableToCreateURL,
-				),
-			),
-			)
-
-			return nil
-		}
-
-		h.logger.Debug("created url", zap.String("url", url))
-
-		// Make the request.
-		apiCtx, cancel := context.WithTimeout(ctx, h.config.Timeout)
-		defer cancel()
-
-		resp, err = h.requestHandler.Do(apiCtx, url)
-		if err != nil {
-			status := providertypes.ErrorUnknown
-			if resp != nil {
-				status = providertypes.ErrorCode(resp.StatusCode)
-			}
-			h.writeResponse(ctx, responseCh, providertypes.NewGetResponseWithErr[K, V](
-				ids,
-				providertypes.NewErrorWithCode(
-					errors.ErrDoRequestWithErr(err),
-					status,
-				),
-			),
-			)
-			return nil
-		}
-
-		// TODO: add more error handling here.
-		var response providertypes.GetResponse[K, V]
-		switch {
-		case resp.StatusCode == http.StatusTooManyRequests:
-			response = providertypes.NewGetResponseWithErr[K, V](
-				ids,
-				providertypes.NewErrorWithCode(
-					errors.ErrRateLimit,
-					providertypes.ErrorRateLimitExceeded,
-				),
-			)
-		case resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices:
-			response = providertypes.NewGetResponseWithErr[K, V](
-				ids,
-				providertypes.NewErrorWithCode(
-					errors.ErrUnexpectedStatusCodeWithCode(resp.StatusCode),
-					providertypes.ErrorCode(resp.StatusCode),
-				),
-			)
-		default:
-			response = h.apiHandler.ParseResponse(ids, resp)
-		}
-
-		h.writeResponse(ctx, responseCh, response)
+		h.writeResponse(ctx, responseCh, h.priceFetcher.FetchPrices(ctx, ids))
 		return nil
 	}
 }

--- a/providers/base/api/handlers/api_query_handler.go
+++ b/providers/base/api/handlers/api_query_handler.go
@@ -39,7 +39,7 @@ type APIPriceFetcher[K providertypes.ResponseKey, V providertypes.ResponseValue]
 	FetchPrices(
 		ctx context.Context,
 		ids []K,
-	) (providertypes.GetResponse[K, V])
+	) providertypes.GetResponse[K, V]
 }
 
 // APIQueryHandlerImpl is the default API implementation of the QueryHandler interface.
@@ -88,10 +88,10 @@ func NewAPIQueryHandler[K providertypes.ResponseKey, V providertypes.ResponseVal
 	}
 
 	return &APIQueryHandlerImpl[K, V]{
-		logger:         logger.With(zap.String("api_data_handler", cfg.Name)),
-		config:         cfg,
-		metrics:        metrics,
-		priceFetcher:   priceFetcher,
+		logger:       logger.With(zap.String("api_data_handler", cfg.Name)),
+		config:       cfg,
+		metrics:      metrics,
+		priceFetcher: priceFetcher,
 	}, nil
 }
 

--- a/providers/base/api/handlers/api_query_handler_test.go
+++ b/providers/base/api/handlers/api_query_handler_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"strings"
@@ -644,20 +645,20 @@ func TestAPIQueryHandler(t *testing.T) {
 func newRateLimitResponse() *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusTooManyRequests,
-		Body:       nil,
+		Body:       io.NopCloser(strings.NewReader(`{"error": "rate limit exceeded"}`)),
 	}
 }
 
 func newUnexpectedStatusCodeResponse() *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusInternalServerError,
-		Body:       nil,
+		Body:       io.NopCloser(strings.NewReader(`{"error": "unexpected error"}`)),
 	}
 }
 
 func newValidResponse() *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       nil,
+		Body:       io.NopCloser(strings.NewReader(`{"result": "100"}`)),
 	}
 }

--- a/providers/base/api/handlers/rest_api_price_fetcher.go
+++ b/providers/base/api/handlers/rest_api_price_fetcher.go
@@ -1,0 +1,140 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"go.uber.org/zap"
+
+	"github.com/skip-mev/slinky/oracle/config"
+	"github.com/skip-mev/slinky/providers/base/api/errors"
+	"github.com/skip-mev/slinky/providers/base/api/metrics"
+	providertypes "github.com/skip-mev/slinky/providers/types"
+)
+
+// RestAPIPriceFetcher handles the logic of fetching prices from a REST API. This implementation
+// depends on an APIDataHandler to handle the creation of URLs / parsing the API response.
+type RestAPIPriceFetcher[K providertypes.ResponseKey, V providertypes.ResponseValue] struct {
+	// requestHandler is responsible for making outgoing HTTP requests with a given URL.
+	requestHandler RequestHandler
+
+	// apiDataHandler is responsible for creating URLs and parsing the API response.
+	apiDataHandler APIDataHandler[K, V]
+
+	// metrics is responsible for tracking metrics related to the API.
+	metrics metrics.APIMetrics
+
+	// config is the configuration for the API. Specifically configuring the timeouts
+	// for outgoing requests
+	config config.APIConfig
+
+	// logger
+	logger *zap.Logger
+}
+
+// NewRestAPIPriceFetcher creates a new RestAPIPriceFetcher.
+func NewRestAPIPriceFetcher[K providertypes.ResponseKey, V providertypes.ResponseValue](
+	requestHandler RequestHandler,
+	apiDataHandler APIDataHandler[K, V],
+	metrics metrics.APIMetrics,
+	config config.APIConfig,
+	logger *zap.Logger,
+) (*RestAPIPriceFetcher[K, V], error) {
+	if err := config.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
+	if !config.Enabled {
+		return nil, fmt.Errorf("api is disabled")
+	}
+
+	if requestHandler == nil {
+		return nil, fmt.Errorf("request handler is nil")
+	}
+
+	if apiDataHandler == nil {
+		return nil, fmt.Errorf("api data handler is nil")
+	}
+
+	if metrics == nil {
+		return nil, fmt.Errorf("metrics is nil")
+	}
+
+	return &RestAPIPriceFetcher[K, V]{
+		requestHandler: requestHandler,
+		apiDataHandler: apiDataHandler,
+		metrics:        metrics,
+		config:         config,
+		logger:         logger,
+	}, nil
+}
+
+func (pf *RestAPIPriceFetcher[K, V]) FetchPrices(
+	ctx context.Context,
+	ids []K,
+) providertypes.GetResponse[K, V] {
+	// Create the URL for the request.
+	url, err := pf.apiDataHandler.CreateURL(ids)
+	if err != nil {
+		return providertypes.NewGetResponseWithErr[K, V](
+			ids,
+			providertypes.NewErrorWithCode(
+				errors.ErrCreateURLWithErr(err),
+				providertypes.ErrorUnableToCreateURL,
+			),
+		)
+	}
+
+	pf.logger.Debug("created url", zap.String("url", url))
+
+	// Make the request.
+	apiCtx, cancel := context.WithTimeout(ctx, pf.config.Timeout)
+	defer cancel()
+
+	pf.logger.Debug("making request", zap.String("url", url))
+	resp, err := pf.requestHandler.Do(apiCtx, url)
+	if err != nil {
+		status := providertypes.ErrorUnknown
+		if resp != nil {
+			status = providertypes.ErrorCode(resp.StatusCode)
+		}
+		return providertypes.NewGetResponseWithErr[K, V](
+			ids,
+			providertypes.NewErrorWithCode( // TODO(nikhil): coordinate api-errors w/ correct metric codes
+				errors.ErrDoRequestWithErr(err),
+				status,
+			),
+		)
+	}
+	defer resp.Body.Close()
+	// Record the status code in the metrics.
+	pf.metrics.AddHTTPStatusCode(pf.config.Name, resp)
+
+	pf.logger.Debug("received response", zap.Int("status_code", resp.StatusCode))
+	// TODO: add more error handling here.
+	// TODO(nikhil): move this logic to a shared HTTPClient
+	var response providertypes.GetResponse[K, V]
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		response = providertypes.NewGetResponseWithErr[K, V](
+			ids,
+			providertypes.NewErrorWithCode(
+				errors.ErrRateLimit,
+				providertypes.ErrorRateLimitExceeded,
+			),
+		)
+	case resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices:
+		response = providertypes.NewGetResponseWithErr[K, V](
+			ids,
+			providertypes.NewErrorWithCode(
+				errors.ErrUnexpectedStatusCodeWithCode(resp.StatusCode),
+				providertypes.ErrorCode(resp.StatusCode),
+			),
+		)
+	default:
+		response = pf.apiDataHandler.ParseResponse(ids, resp)
+	}
+
+	return response
+}

--- a/providers/base/api/metrics/mocks/mock_metrics.go
+++ b/providers/base/api/metrics/mocks/mock_metrics.go
@@ -5,8 +5,9 @@ package mocks
 import (
 	http "net/http"
 
-	metrics "github.com/skip-mev/slinky/providers/base/api/metrics"
 	mock "github.com/stretchr/testify/mock"
+
+	metrics "github.com/skip-mev/slinky/providers/base/api/metrics"
 
 	time "time"
 )

--- a/providers/static/client.go
+++ b/providers/static/client.go
@@ -2,9 +2,11 @@ package static
 
 import (
 	"context"
+	"io"
 	"net/http"
 
 	"github.com/skip-mev/slinky/providers/base/api/handlers"
+	"strings"
 )
 
 var _ handlers.RequestHandler = (*MockClient)(nil)
@@ -21,6 +23,7 @@ func NewStaticMockClient() *MockClient {
 func (s *MockClient) Do(_ context.Context, _ string) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(`{"result": "success"}`)),
 	}, nil
 }
 

--- a/providers/static/client.go
+++ b/providers/static/client.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/skip-mev/slinky/providers/base/api/handlers"
-	"strings"
 )
 
 var _ handlers.RequestHandler = (*MockClient)(nil)
@@ -23,7 +23,7 @@ func NewStaticMockClient() *MockClient {
 func (s *MockClient) Do(_ context.Context, _ string) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Body: io.NopCloser(strings.NewReader(`{"result": "success"}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"result": "success"}`)),
 	}, nil
 }
 


### PR DESCRIPTION
## In This PR
- I introduce a `PriceFetcher` and have the `APIQueryHandler` depend on that interface
- This way, the logic executed in the `subTask` of each `APIQueryHandler` can be abstracted so that we can handle
    - REST API interactions
    - JSON-RPC client interactions (w/ custom client code): raydium / eth
    - GRPC client interactions: geyser for solana, etc
### Let's Discuss
- The metrics for the API providers is [messy](https://linear.app/skip/issue/BLO-1046/incorrect-handling-of-error-codes-metric-response-for-api-providers)
  - We should consolidate error-codes / error-types between the metrics pkg / providers pkg
- Our handling of the HTTP life-cycle is [incorrect](https://linear.app/skip/issue/BLO-1047/http-response-body-is-never-closed-in-api-query-handler)
   - Fixed in this PR
- Broadly speaking, our HTTP error code handling + metric reporting should be abstracted behind a shared `HTTPClient` interface (the `RequestHandler` currently does this, but does not accomplish much outside of wrapping the default `http.Client` impl
     - We shld remove the `RequestHandler` interface, and j introduce an `HTTPClient` interface
     - Move all of our HTTP error handling logic there
     - Introduce implementations that allow for fallback, retry, aggregation, etc + share them across all providers