### PR TITLE
fix(ci): build cross-arch images only on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ startsWith(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
       - uses: cloudposse/github-action-matrix-outputs-write@1.0.0
         id: out
         with:


### PR DESCRIPTION
To save money and time, we should only build crossarch images on release (tags starting with v). Let me know if you have any questions about the weird-looking ternary operator.