### PR TITLE
fix: raydium decimals handling

### DIFF
--- a/providers/apis/defi/raydium/price_fetcher.go
+++ b/providers/apis/defi/raydium/price_fetcher.go
@@ -214,8 +214,7 @@ func (pf *APIPriceFetcher) Fetch(
 		baseAccount := accountsResp.Value[i*2]
 		quoteAccount := accountsResp.Value[i*2+1]
 
-		metadata := pf.metaDataPerTicker[ticker.String()]
-
+		metadata := pf.metaDataPerTicker[ticker.GetJSON()]
 		// parse the token balances
 		baseTokenBalance, err := getScaledTokenBalance(baseAccount)
 		if err != nil {
@@ -228,6 +227,12 @@ func (pf *APIPriceFetcher) Fetch(
 			}
 			continue
 		}
+		pf.logger.Info(
+			"base token balance", zap.String("ticker", ticker.String()),
+			zap.String("balance", baseTokenBalance.String()),
+			zap.String("account", accounts[i * 2].String()),
+		)
+
 
 		quoteTokenBalance, err := getScaledTokenBalance(quoteAccount)
 		if err != nil {
@@ -241,10 +246,19 @@ func (pf *APIPriceFetcher) Fetch(
 			continue
 		}
 
-		pf.logger.Debug(
+		pf.logger.Info(
+			"quote token balance", zap.String("ticker", ticker.String()),
+			zap.String("balance", quoteTokenBalance.String()),
+			zap.String("account", accounts[i * 2 + 1].String()),
+		)
+
+		pf.logger.Info(
 			"unscaled balances",
 			zap.String("base", baseTokenBalance.String()),
 			zap.String("quote", quoteTokenBalance.String()),
+			zap.Uint64("base decimals", metadata.BaseTokenVault.TokenDecimals),
+			zap.Uint64("quote decimals", metadata.QuoteTokenVault.TokenDecimals),
+			zap.String("ticker", ticker.String()),
 		)
 
 		// calculate the price
@@ -253,7 +267,7 @@ func (pf *APIPriceFetcher) Fetch(
 			metadata.BaseTokenVault.TokenDecimals, metadata.QuoteTokenVault.TokenDecimals,
 		)
 
-		pf.logger.Debug(
+		pf.logger.Info(
 			"scaled price",
 			zap.String("ticker", ticker.String()),
 			zap.String("price", price.String()),

--- a/providers/apis/defi/raydium/price_fetcher.go
+++ b/providers/apis/defi/raydium/price_fetcher.go
@@ -227,12 +227,6 @@ func (pf *APIPriceFetcher) Fetch(
 			}
 			continue
 		}
-		pf.logger.Info(
-			"base token balance", zap.String("ticker", ticker.String()),
-			zap.String("balance", baseTokenBalance.String()),
-			zap.String("account", accounts[i * 2].String()),
-		)
-
 
 		quoteTokenBalance, err := getScaledTokenBalance(quoteAccount)
 		if err != nil {
@@ -246,19 +240,10 @@ func (pf *APIPriceFetcher) Fetch(
 			continue
 		}
 
-		pf.logger.Info(
-			"quote token balance", zap.String("ticker", ticker.String()),
-			zap.String("balance", quoteTokenBalance.String()),
-			zap.String("account", accounts[i * 2 + 1].String()),
-		)
-
-		pf.logger.Info(
+		pf.logger.Debug(
 			"unscaled balances",
 			zap.String("base", baseTokenBalance.String()),
 			zap.String("quote", quoteTokenBalance.String()),
-			zap.Uint64("base decimals", metadata.BaseTokenVault.TokenDecimals),
-			zap.Uint64("quote decimals", metadata.QuoteTokenVault.TokenDecimals),
-			zap.String("ticker", ticker.String()),
 		)
 
 		// calculate the price
@@ -267,7 +252,7 @@ func (pf *APIPriceFetcher) Fetch(
 			metadata.BaseTokenVault.TokenDecimals, metadata.QuoteTokenVault.TokenDecimals,
 		)
 
-		pf.logger.Info(
+		pf.logger.Debug(
 			"scaled price",
 			zap.String("ticker", ticker.String()),
 			zap.String("price", price.String()),

--- a/providers/apis/defi/raydium/price_fetcher.go
+++ b/providers/apis/defi/raydium/price_fetcher.go
@@ -214,7 +214,18 @@ func (pf *APIPriceFetcher) Fetch(
 		baseAccount := accountsResp.Value[i*2]
 		quoteAccount := accountsResp.Value[i*2+1]
 
-		metadata := pf.metaDataPerTicker[ticker.String()]
+		metadata, ok := pf.metaDataPerTicker[ticker.String()]
+		if !ok {
+			pf.logger.Error("metadata not found for ticker", zap.String("ticker", ticker.String()))
+			unresolved[ticker] = providertypes.UnresolvedResult{
+				ErrorWithCode: providertypes.NewErrorWithCode(
+					NoRaydiumMetadataForTickerError(ticker.String()),
+					providertypes.ErrorUnknownPair,
+				),
+			}
+			continue
+		}
+
 		// parse the token balances
 		baseTokenBalance, err := getScaledTokenBalance(baseAccount)
 		if err != nil {

--- a/providers/apis/defi/raydium/price_fetcher.go
+++ b/providers/apis/defi/raydium/price_fetcher.go
@@ -214,7 +214,7 @@ func (pf *APIPriceFetcher) Fetch(
 		baseAccount := accountsResp.Value[i*2]
 		quoteAccount := accountsResp.Value[i*2+1]
 
-		metadata := pf.metaDataPerTicker[ticker.GetJSON()]
+		metadata := pf.metaDataPerTicker[ticker.String()]
 		// parse the token balances
 		baseTokenBalance, err := getScaledTokenBalance(baseAccount)
 		if err != nil {

--- a/providers/apis/defi/raydium/price_fetcher_test.go
+++ b/providers/apis/defi/raydium/price_fetcher_test.go
@@ -363,7 +363,7 @@ func TestProviderFetch(t *testing.T) {
 
 		require.True(t, strings.Contains(resp.UnResolved[tickers[0]].Error(), "solana json-rpc error"))
 		result := resp.Resolved[tickers[1]]
-		require.Equal(t, result.Value.SetPrec(30), big.NewFloat(3e-12).SetPrec(30))
+		require.Equal(t, result.Value.SetPrec(30), big.NewFloat(3).SetPrec(30))
 	})
 
 	t.Run("incorrectly encoded accounts are handled gracefully", func(t *testing.T) {

--- a/providers/apis/defi/raydium/types.go
+++ b/providers/apis/defi/raydium/types.go
@@ -22,18 +22,18 @@ const (
 // updateMetaDataCache unmarshals the metadata JSON for each ticker and adds it to the
 // metadata map.
 func (pf *APIPriceFetcher) updateMetaDataCache(ticker types.ProviderTicker) (TickerMetadata, error) {
-	if metadata, ok := pf.metaDataPerTicker[ticker.GetJSON()]; ok {
+	if metadata, ok := pf.metaDataPerTicker[ticker.String()]; ok {
 		return metadata, nil
 	}
 
-	metadata, err := unmarshalMetadataJSON(ticker.GetJSON())
+	metadata, err := unmarshalMetadataJSON(ticker.String())
 	if err != nil {
 		return TickerMetadata{}, fmt.Errorf("error unmarshalling metadata for ticker %s: %w", ticker.String(), err)
 	}
 	if err := metadata.ValidateBasic(); err != nil {
 		return TickerMetadata{}, fmt.Errorf("metadata for ticker %s is invalid: %w", ticker.String(), err)
 	}
-	pf.metaDataPerTicker[ticker.GetJSON()] = metadata
+	pf.metaDataPerTicker[ticker.String()] = metadata
 
 	return metadata, nil
 }

--- a/providers/apis/defi/raydium/types.go
+++ b/providers/apis/defi/raydium/types.go
@@ -26,7 +26,7 @@ func (pf *APIPriceFetcher) updateMetaDataCache(ticker types.ProviderTicker) (Tic
 		return metadata, nil
 	}
 
-	metadata, err := unmarshalMetadataJSON(ticker.String())
+	metadata, err := unmarshalMetadataJSON(ticker.GetJSON())
 	if err != nil {
 		return TickerMetadata{}, fmt.Errorf("error unmarshalling metadata for ticker %s: %w", ticker.String(), err)
 	}

--- a/providers/apis/defi/raydium/types.go
+++ b/providers/apis/defi/raydium/types.go
@@ -30,6 +30,7 @@ func (pf *APIPriceFetcher) updateMetaDataCache(ticker types.ProviderTicker) (Tic
 	if err != nil {
 		return TickerMetadata{}, fmt.Errorf("error unmarshalling metadata for ticker %s: %w", ticker.String(), err)
 	}
+
 	if err := metadata.ValidateBasic(); err != nil {
 		return TickerMetadata{}, fmt.Errorf("metadata for ticker %s is invalid: %w", ticker.String(), err)
 	}

--- a/providers/apis/defi/raydium/types.go
+++ b/providers/apis/defi/raydium/types.go
@@ -30,7 +30,6 @@ func (pf *APIPriceFetcher) updateMetaDataCache(ticker types.ProviderTicker) (Tic
 	if err != nil {
 		return TickerMetadata{}, fmt.Errorf("error unmarshalling metadata for ticker %s: %w", ticker.String(), err)
 	}
-
 	if err := metadata.ValidateBasic(); err != nil {
 		return TickerMetadata{}, fmt.Errorf("metadata for ticker %s is invalid: %w", ticker.String(), err)
 	}


### PR DESCRIPTION
## In This PR
- I fix a regression introduced in raydium's handling of decimals introduced in [this](https://github.com/skip-mev/slinky/pull/265/files#diff-f462408188e3abad00b62069a35b2b6d8701f4b6e2caa5b160965ea49e5b374eR24) PR
- Specifically, we incorrectly used the ticker's meta-data json as the index into the `tickerMetadata` map instead of using the ticker's human readable string