### PR TITLE
fix: Allow 0 decimal ERC20 contracts in uniswapv3

### DIFF
--- a/providers/apis/defi/uniswapv3/utils.go
+++ b/providers/apis/defi/uniswapv3/utils.go
@@ -62,12 +62,12 @@ func (pc *PoolConfig) ValidateBasic() error {
 		return fmt.Errorf("pool address is not a valid ethereum address")
 	}
 
-	if pc.BaseDecimals <= 0 {
-		return fmt.Errorf("base decimals must be positive")
+	if pc.BaseDecimals < 0 {
+		return fmt.Errorf("base decimals must be non-negative")
 	}
 
-	if pc.QuoteDecimals <= 0 {
-		return fmt.Errorf("quote decimals must be positive")
+	if pc.QuoteDecimals < 0 {
+		return fmt.Errorf("quote decimals must be non-negative")
 	}
 
 	return nil

--- a/providers/apis/defi/uniswapv3/utils_test.go
+++ b/providers/apis/defi/uniswapv3/utils_test.go
@@ -26,7 +26,7 @@ func TestPoolConfig(t *testing.T) {
 	t.Run("invalid base decimals", func(t *testing.T) {
 		cfg := uniswapv3.PoolConfig{
 			Address:      "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8",
-			BaseDecimals: 0,
+			BaseDecimals: -1,
 		}
 		require.Error(t, cfg.ValidateBasic())
 	})
@@ -35,7 +35,7 @@ func TestPoolConfig(t *testing.T) {
 		cfg := uniswapv3.PoolConfig{
 			Address:       "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8",
 			BaseDecimals:  18,
-			QuoteDecimals: 0,
+			QuoteDecimals: -1,
 		}
 		require.Error(t, cfg.ValidateBasic())
 	})


### PR DESCRIPTION
Allow 0 decimal ERC20 assets. Only error on non-negative values.

BLO-1300