### PR TITLE
chore: Fix goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 ---
 project_name: slinky
 
@@ -24,10 +25,6 @@ archives:
         format: zip
     name_template: "{{ .Binary }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     files:
-      - ./config/local/market.json
-      - ./config/local/oracle.json
-      - ./config/dydx/market.json
-      - ./config/dydx/oracle.json
       - README.md
 
 snapshot:


### PR DESCRIPTION
Goreleaser updated to v2, we also have a couple of config files leftover I remove.
![Screenshot 2024-06-05 at 11 53 22 AM](https://github.com/skip-mev/slinky/assets/10753834/64f92655-0a6c-4016-82ab-b76a383746e7)

