### PR TITLE
fix: move abci logs to debug

### DIFF
--- a/abci/preblock/oracle/preblock.go
+++ b/abci/preblock/oracle/preblock.go
@@ -89,7 +89,7 @@ func (h *PreBlockHandler) PreBlocker() sdk.PreBlocker {
 			// only measure latency in Finalize
 			if ctx.ExecMode() == sdk.ExecModeFinalize {
 				latency := time.Since(start)
-				h.logger.Info(
+				h.logger.Debug(
 					"finished executing the pre-block hook",
 					"height", ctx.BlockHeight(),
 					"latency (seconds)", latency.Seconds(),
@@ -117,7 +117,7 @@ func (h *PreBlockHandler) PreBlocker() sdk.PreBlocker {
 			return &sdk.ResponsePreBlock{}, nil
 		}
 
-		h.logger.Info(
+		h.logger.Debug(
 			"executing the pre-finalize block hook",
 			"height", req.Height,
 		)
@@ -133,8 +133,6 @@ func (h *PreBlockHandler) PreBlocker() sdk.PreBlocker {
 
 			return &sdk.ResponsePreBlock{}, err
 		}
-
-		h.logger.Info("finished executing the oracle pre-block hook")
 
 		return &sdk.ResponsePreBlock{}, nil
 	}

--- a/abci/proposals/proposals.go
+++ b/abci/proposals/proposals.go
@@ -107,7 +107,7 @@ func (h *ProposalHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 		// report the slinky specific PrepareProposal latency
 		defer func() {
 			totalLatency := time.Since(startTime)
-			h.logger.Info(
+			h.logger.Debug(
 				"recording handle time metrics of prepare-proposal (seconds)",
 				"total latency", totalLatency.Seconds(),
 				"wrapped prepare proposal latency", wrappedPrepareProposalLatency.Seconds(),
@@ -130,7 +130,7 @@ func (h *ProposalHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 		// for the current block.
 		voteExtensionsEnabled := ve.VoteExtensionsEnabled(ctx)
 		if voteExtensionsEnabled {
-			h.logger.Info(
+			h.logger.Debug(
 				"injecting oracle data into proposal",
 				"height", req.Height,
 				"vote_extensions_enabled", voteExtensionsEnabled,
@@ -200,12 +200,12 @@ func (h *ProposalHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 
 			return &cometabci.ResponsePrepareProposal{Txs: make([][]byte, 0)}, err
 		}
-		h.logger.Info("wrapped prepareProposalHandler produced response ", "txs", len(resp.Txs))
+		h.logger.Debug("wrapped prepareProposalHandler produced response ", "txs", len(resp.Txs))
 
 		// Inject our VE Tx ( if extInfoBz is non-empty), and resize our response Txs to respect req.MaxTxBytes
 		resp.Txs = h.injectAndResize(resp.Txs, extInfoBz, req.MaxTxBytes+int64(len(extInfoBz)))
 
-		h.logger.Info(
+		h.logger.Debug(
 			"prepared proposal",
 			"txs", len(resp.Txs),
 			"vote_extensions_enabled", voteExtensionsEnabled,
@@ -261,7 +261,7 @@ func (h *ProposalHandler) ProcessProposalHandler() sdk.ProcessProposalHandler {
 		defer func() {
 			// record latency
 			totalLatency := time.Since(start)
-			h.logger.Info(
+			h.logger.Debug(
 				"recording handle time metrics of process-proposal (seconds)",
 				"total latency", totalLatency.Seconds(),
 				"wrapped prepare proposal latency", wrappedProcessProposalLatency.Seconds(),
@@ -281,7 +281,7 @@ func (h *ProposalHandler) ProcessProposalHandler() sdk.ProcessProposalHandler {
 
 		voteExtensionsEnabled := ve.VoteExtensionsEnabled(ctx)
 
-		h.logger.Info(
+		h.logger.Debug(
 			"processing proposal",
 			"height", req.Height,
 			"num_txs", len(req.Txs),

--- a/abci/strategies/aggregator/price_applier.go
+++ b/abci/strategies/aggregator/price_applier.go
@@ -103,7 +103,7 @@ func (opa *oraclePriceApplier) ApplyPricesFromVoteExtensions(ctx sdk.Context, re
 	for _, cp := range currencyPairs {
 		price, ok := prices[cp]
 		if !ok || price == nil {
-			opa.logger.Info(
+			opa.logger.Debug(
 				"no price for currency pair",
 				"currency_pair", cp.String(),
 			)
@@ -139,7 +139,7 @@ func (opa *oraclePriceApplier) ApplyPricesFromVoteExtensions(ctx sdk.Context, re
 			return nil, err
 		}
 
-		opa.logger.Info(
+		opa.logger.Debug(
 			"set price for currency pair",
 			"currency_pair", cp.String(),
 			"quote_price", quotePrice.Price.String(),

--- a/abci/strategies/aggregator/vote_aggregator.go
+++ b/abci/strategies/aggregator/vote_aggregator.go
@@ -137,7 +137,7 @@ func (dva *DefaultVoteAggregator) AggregateOracleVotes(ctx sdk.Context, votes []
 	dva.priceAggregator.AggregateDataFromContext(ctx)
 	prices := dva.priceAggregator.GetAggregatedData()
 
-	dva.logger.Info(
+	dva.logger.Debug(
 		"aggregated oracle data",
 		"num_prices", len(prices),
 	)

--- a/abci/strategies/currencypair/delta.go
+++ b/abci/strategies/currencypair/delta.go
@@ -46,7 +46,7 @@ func (s *DeltaCurrencyPairStrategy) GetEncodedPrice(
 
 	deltaPrice := new(big.Int).Sub(price, onChainPrice)
 
-	ctx.Logger().Info(
+	ctx.Logger().Debug(
 		"encoded oracle price",
 		"currency_pair", cp.String(),
 		"price", deltaPrice.String(),

--- a/abci/ve/vote_extension.go
+++ b/abci/ve/vote_extension.go
@@ -93,7 +93,7 @@ func (h *VoteExtensionHandler) ExtendVoteHandler() sdk.ExtendVoteHandler {
 
 			// measure latency
 			latency := time.Since(start)
-			h.logger.Info(
+			h.logger.Debug(
 				"extend vote handler",
 				"duration (seconds)", latency.Seconds(),
 				"err", err,
@@ -198,7 +198,7 @@ func (h *VoteExtensionHandler) ExtendVoteHandler() sdk.ExtendVoteHandler {
 			return &cometabci.ResponseExtendVote{VoteExtension: []byte{}}, err
 		}
 
-		h.logger.Info(
+		h.logger.Debug(
 			"extending vote with oracle prices",
 			"req_height", req.Height,
 		)
@@ -218,7 +218,7 @@ func (h *VoteExtensionHandler) VerifyVoteExtensionHandler() sdk.VerifyVoteExtens
 		// measure latencies from invocation to return
 		defer func() {
 			latency := time.Since(start)
-			h.logger.Info(
+			h.logger.Debug(
 				"verify vote extension handler",
 				"duration (seconds)", latency.Seconds(),
 			)
@@ -272,7 +272,7 @@ func (h *VoteExtensionHandler) VerifyVoteExtensionHandler() sdk.VerifyVoteExtens
 			return &cometabci.ResponseVerifyVoteExtension{Status: cometabci.ResponseVerifyVoteExtension_REJECT}, err
 		}
 
-		h.logger.Info(
+		h.logger.Debug(
 			"validated vote extension",
 			"height", req.Height,
 			"size (bytes)", len(req.VoteExtension),


### PR DESCRIPTION
## In This PR
- I move all unnecessary `Info` logs to `Debug`
- I also remove a redundant log in the `FinalizeBlock`