### PR TITLE
feat: Add delete market to keeper, for future proofing

### DIFF
--- a/x/marketmap/keeper/keeper.go
+++ b/x/marketmap/keeper/keeper.go
@@ -118,7 +118,9 @@ func (k *Keeper) UpdateMarket(ctx sdk.Context, market types.Market) error {
 	return k.markets.Set(ctx, types.TickerString(market.Ticker.String()), market)
 }
 
-// DeleteMarket updates a Market.
+// DeleteMarket removes a Market.
+// This is currently only expected to be called in upgrade handlers, and callers will need to separately call
+// RemoveCurrencyPair on x/oracle to clean up leftover state in that module.
 func (k *Keeper) DeleteMarket(ctx sdk.Context, tickerStr string) error {
 	// Check if Ticker exists
 	alreadyExists, err := k.markets.Has(ctx, types.TickerString(tickerStr))

--- a/x/marketmap/keeper/keeper.go
+++ b/x/marketmap/keeper/keeper.go
@@ -128,7 +128,6 @@ func (k *Keeper) DeleteMarket(ctx sdk.Context, tickerStr string) error {
 	if !alreadyExists {
 		return types.NewMarketDoesNotExistsError(types.TickerString(tickerStr))
 	}
-	// Create the config
 	return k.markets.Remove(ctx, types.TickerString(tickerStr))
 }
 

--- a/x/marketmap/keeper/keeper.go
+++ b/x/marketmap/keeper/keeper.go
@@ -118,6 +118,20 @@ func (k *Keeper) UpdateMarket(ctx sdk.Context, market types.Market) error {
 	return k.markets.Set(ctx, types.TickerString(market.Ticker.String()), market)
 }
 
+// DeleteMarket updates a Market.
+func (k *Keeper) DeleteMarket(ctx sdk.Context, tickerStr string) error {
+	// Check if Ticker exists
+	alreadyExists, err := k.markets.Has(ctx, types.TickerString(tickerStr))
+	if err != nil {
+		return err
+	}
+	if !alreadyExists {
+		return types.NewMarketDoesNotExistsError(types.TickerString(tickerStr))
+	}
+	// Create the config
+	return k.markets.Remove(ctx, types.TickerString(tickerStr))
+}
+
 // SetParams sets the x/marketmap module's parameters.
 func (k *Keeper) SetParams(ctx sdk.Context, params types.Params) error {
 	return k.params.Set(ctx, params)

--- a/x/marketmap/keeper/keeper_test.go
+++ b/x/marketmap/keeper/keeper_test.go
@@ -272,3 +272,16 @@ func (s *KeeperTestSuite) TestValidUpdate() {
 	s.Require().NoError(s.keeper.UpdateMarket(s.ctx, validMarket))
 	s.Require().NoError(s.keeper.ValidateState(s.ctx, []types.Market{validMarket}))
 }
+
+func (s *KeeperTestSuite) TestDeleteMarket() {
+	// create a valid markets
+	s.Require().NoError(s.keeper.CreateMarket(s.ctx, btcusdt))
+
+	// invalid delete fails
+	s.Require().Error(s.keeper.DeleteMarket(s.ctx, "foobar"))
+
+	// valid delete works
+	s.Require().NoError(s.keeper.DeleteMarket(s.ctx, btcusdt.Ticker.String()))
+	_, err := s.keeper.GetMarket(s.ctx, btcusdt.Ticker.String())
+	s.Require().Error(err)
+}


### PR DESCRIPTION
Add delete method to x/mm keeper, so that in the future we can use this to remove markets in upgrade handlers. 

I haven't added any actual handling/msgs since we currently don't want to do this via  on chain txn.

closes BLO-1387