### PR TITLE
chore: Add interface to ve

### DIFF
--- a/abci/types/interfaces.go
+++ b/abci/types/interfaces.go
@@ -1,13 +1,17 @@
 package types
 
 import (
+	"context"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"google.golang.org/grpc"
 
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
+	servertypes "github.com/skip-mev/slinky/service/servers/oracle/types"
 	oracletypes "github.com/skip-mev/slinky/x/oracle/types"
 )
 
-// Keeper defines the interface that must be fulfilled by the oracle keeper. This
+// OracleKeeper defines the interface that must be fulfilled by the oracle keeper. This
 // interface is utilized by the PreBlock handler to write oracle data to state for the
 // supported assets.
 //
@@ -15,4 +19,10 @@ import (
 type OracleKeeper interface { //golint:ignore
 	GetAllCurrencyPairs(ctx sdk.Context) []slinkytypes.CurrencyPair
 	SetPriceForCurrencyPair(ctx sdk.Context, cp slinkytypes.CurrencyPair, qp oracletypes.QuotePrice) error
+}
+
+// OracleClient defines the interface that must be fulfilled by the slinky client.
+// This interface is utilized by the vote extension handler to fetch prices.
+type OracleClient interface {
+	Prices(ctx context.Context, in *servertypes.QueryPricesRequest, opts ...grpc.CallOption) (*servertypes.QueryPricesResponse, error)
 }

--- a/abci/ve/vote_extension.go
+++ b/abci/ve/vote_extension.go
@@ -30,7 +30,7 @@ type VoteExtensionHandler struct {
 	logger log.Logger
 
 	// oracleClient is the remote oracle client that is responsible for fetching prices
-	oracleClient client.OracleClient
+	oracleClient slinkyabci.OracleClient
 
 	// timeout is the maximum amount of time to wait for the oracle to respond
 	// to a price request.

--- a/abci/ve/vote_extension.go
+++ b/abci/ve/vote_extension.go
@@ -17,7 +17,6 @@ import (
 	slinkyabci "github.com/skip-mev/slinky/abci/types"
 	"github.com/skip-mev/slinky/abci/ve/types"
 	slinkytypes "github.com/skip-mev/slinky/pkg/types"
-	client "github.com/skip-mev/slinky/service/clients/oracle"
 	servicemetrics "github.com/skip-mev/slinky/service/metrics"
 	servicetypes "github.com/skip-mev/slinky/service/servers/oracle/types"
 )
@@ -53,7 +52,7 @@ type VoteExtensionHandler struct {
 // NewVoteExtensionHandler returns a new VoteExtensionHandler.
 func NewVoteExtensionHandler(
 	logger log.Logger,
-	oracleClient client.OracleClient,
+	oracleClient slinkyabci.OracleClient,
 	timeout time.Duration,
 	strategy currencypair.CurrencyPairStrategy,
 	codec compression.VoteExtensionCodec,


### PR DESCRIPTION
Removes the additional method dependencies from the oracle client in the vote extension handler. The only thing relevant is the Prices call, and the additional methods add unnecessary complexity to the dydx implementation.