### PR TITLE
fix: add protection around marketmap hooks

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -10,10 +10,11 @@ import (
 	"syscall"
 	"time"
 
-	slinkygrpc "github.com/skip-mev/slinky/pkg/grpc"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	slinkygrpc "github.com/skip-mev/slinky/pkg/grpc"
 
 	"github.com/skip-mev/slinky/service/servers/oracle/types"
 )

--- a/providers/apis/bitstamp/api_handler_test.go
+++ b/providers/apis/bitstamp/api_handler_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/skip-mev/slinky/oracle/types"
 	"github.com/skip-mev/slinky/providers/apis/bitstamp"
 	"github.com/skip-mev/slinky/providers/base/testutils"
 	providertypes "github.com/skip-mev/slinky/providers/types"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/providers/apis/coinmarketcap/api_handler_test.go
+++ b/providers/apis/coinmarketcap/api_handler_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/skip-mev/slinky/oracle/types"
 	"github.com/skip-mev/slinky/providers/apis/coinmarketcap"
 	"github.com/skip-mev/slinky/providers/base/testutils"
 	providertypes "github.com/skip-mev/slinky/providers/types"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/providers/apis/dydx/switch_over_fetcher_test.go
+++ b/providers/apis/dydx/switch_over_fetcher_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
 	"github.com/skip-mev/slinky/oracle/config"
 	"github.com/skip-mev/slinky/providers/apis/dydx"
 	"github.com/skip-mev/slinky/providers/apis/marketmap"
@@ -17,9 +21,6 @@ import (
 	providertypes "github.com/skip-mev/slinky/providers/types"
 	mmclient "github.com/skip-mev/slinky/service/clients/marketmap/types"
 	mmtypes "github.com/skip-mev/slinky/x/marketmap/types"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestDefaultSwitchOverProvider(t *testing.T) {

--- a/providers/apis/marketmap/client.go
+++ b/providers/apis/marketmap/client.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	slinkygrpc "github.com/skip-mev/slinky/pkg/grpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	slinkygrpc "github.com/skip-mev/slinky/pkg/grpc"
 
 	"github.com/skip-mev/slinky/oracle/config"
 	"github.com/skip-mev/slinky/providers/base/api/metrics"

--- a/service/clients/oracle/client.go
+++ b/service/clients/oracle/client.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"cosmossdk.io/log"
-	slinkygrpc "github.com/skip-mev/slinky/pkg/grpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
+
+	slinkygrpc "github.com/skip-mev/slinky/pkg/grpc"
 
 	"github.com/skip-mev/slinky/oracle/config"
 	"github.com/skip-mev/slinky/service/metrics"

--- a/x/marketmap/keeper/genesis.go
+++ b/x/marketmap/keeper/genesis.go
@@ -30,8 +30,10 @@ func (k *Keeper) InitGenesis(ctx sdk.Context, gs types.GenesisState) {
 		panic(err)
 	}
 
-	if err := k.hooks.AfterMarketGenesis(ctx, gs.MarketMap.Markets); err != nil {
-		panic(err)
+	if k.hooks != nil {
+		if err := k.hooks.AfterMarketGenesis(ctx, gs.MarketMap.Markets); err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/x/marketmap/keeper/hooks.go
+++ b/x/marketmap/keeper/hooks.go
@@ -17,9 +17,5 @@ func (k *Keeper) Hooks() types.MarketMapHooks {
 // SetHooks sets the x/marketmap hooks.  In contrast to other receivers, this method must take a pointer due to nature
 // of the hooks interface and SDK start up sequence.
 func (k *Keeper) SetHooks(mmh types.MarketMapHooks) {
-	if k.hooks != nil {
-		panic("cannot set marketmap hooks twice")
-	}
-
 	k.hooks = mmh
 }

--- a/x/marketmap/keeper/hooks.go
+++ b/x/marketmap/keeper/hooks.go
@@ -8,7 +8,7 @@ import (
 func (k *Keeper) Hooks() types.MarketMapHooks {
 	if k.hooks == nil {
 		// return a no-op implementation if no hooks are set
-		return types.MultiMarketMapHooks{}
+		return &types.NoopMarketMapHooks{}
 	}
 
 	return k.hooks

--- a/x/marketmap/keeper/keeper.go
+++ b/x/marketmap/keeper/keeper.go
@@ -50,6 +50,7 @@ func NewKeeper(ss store.KVStoreService, cdc codec.BinaryCodec, authority sdk.Acc
 		markets:     collections.NewMap(sb, types.MarketsPrefix, "markets", types.TickersCodec, codec.CollValue[types.Market](cdc)),
 		lastUpdated: collections.NewItem[uint64](sb, types.LastUpdatedPrefix, "last_updated", types.LastUpdatedCodec),
 		params:      params,
+		hooks:       &types.NoopMarketMapHooks{},
 	}
 }
 

--- a/x/marketmap/types/hooks.go
+++ b/x/marketmap/types/hooks.go
@@ -64,12 +64,10 @@ type NoopMarketMapHooks struct{}
 
 func (n *NoopMarketMapHooks) AfterMarketCreated(_ sdk.Context, _ Market) error {
 	return nil
-
 }
 
 func (n *NoopMarketMapHooks) AfterMarketUpdated(_ sdk.Context, _ Market) error {
 	return nil
-
 }
 
 func (n *NoopMarketMapHooks) AfterMarketGenesis(_ sdk.Context, _ map[string]Market) error {

--- a/x/marketmap/types/hooks.go
+++ b/x/marketmap/types/hooks.go
@@ -56,3 +56,22 @@ func (mh MultiMarketMapHooks) AfterMarketGenesis(ctx sdk.Context, markets map[st
 
 // MarketMapHooksWrapper is a wrapper for modules to inject MarketMapHooks using depinject.
 type MarketMapHooksWrapper struct{ MarketMapHooks }
+
+var _ MarketMapHooks = &NoopMarketMapHooks{}
+
+// NoopMarketMapHooks defines market map hooks that are a no-op.
+type NoopMarketMapHooks struct{}
+
+func (n *NoopMarketMapHooks) AfterMarketCreated(_ sdk.Context, _ Market) error {
+	return nil
+
+}
+
+func (n *NoopMarketMapHooks) AfterMarketUpdated(_ sdk.Context, _ Market) error {
+	return nil
+
+}
+
+func (n *NoopMarketMapHooks) AfterMarketGenesis(_ sdk.Context, _ map[string]Market) error {
+	return nil
+}

--- a/x/marketmap/types/mocks/MarketMapHooks.go
+++ b/x/marketmap/types/mocks/MarketMapHooks.go
@@ -3,8 +3,9 @@
 package mocks
 
 import (
-	marketmaptypes "github.com/skip-mev/slinky/x/marketmap/types"
 	mock "github.com/stretchr/testify/mock"
+
+	marketmaptypes "github.com/skip-mev/slinky/x/marketmap/types"
 
 	types "github.com/cosmos/cosmos-sdk/types"
 )


### PR DESCRIPTION
- add nil protection check in Genesis
- init the keeper to have no-op hooks by default