### PR TITLE
refactor: add Lint errcheck to Ensure Error Handling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - ineffassign
     - misspell
     - nakedret
+    - errcheck
     - errorlint
     # Checks for pointers to enclosing loop variables.
     - exportloopref

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -104,5 +104,8 @@ func init() {
 }
 
 func main() {
-	rootCmd.Execute()
+	err := rootCmd.Execute()
+	if err != nil {
+		log.Fatalf("failed to execute root command: %v", err)
+	}
 }

--- a/cmd/slinky/config/config_test.go
+++ b/cmd/slinky/config/config_test.go
@@ -339,7 +339,8 @@ func TestReadOracleConfigWithOverrides(t *testing.T) {
 			coinbase.Name,
 			endpointOverride.URL,
 		)
-		tmpfile.Write([]byte(overrides))
+		_, err = tmpfile.Write([]byte(overrides))
+		require.NoError(t, err)
 
 		cfg, err := cmdconfig.ReadOracleConfigWithOverrides(tmpfile.Name(), marketmap.Name)
 		require.NoError(t, err)

--- a/cmd/slinky/main.go
+++ b/cmd/slinky/main.go
@@ -184,7 +184,10 @@ func init() {
 
 // start the oracle-grpc server + oracle process, cancel on interrupt or terminate.
 func main() {
-	rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "error executing command: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func runOracle() error {
@@ -211,8 +214,11 @@ func runOracle() error {
 
 	// Build logger.
 	logger := log.NewLogger(logCfg)
-	defer logger.Sync()
-
+	defer func() {
+		if err := logger.Sync(); err != nil {
+			logger.Error(fmt.Sprintf("failed to sync logger: %v\n", err))
+		}
+	}()
 	var cfg config.OracleConfig
 	var err error
 

--- a/providers/apis/defi/raydium/price_fetcher_test.go
+++ b/providers/apis/defi/raydium/price_fetcher_test.go
@@ -382,14 +382,16 @@ func TestProviderFetch(t *testing.T) {
 		ethVaultTokenMetadata := token.Account{
 			Amount: uint64(1e18),
 		}
-		ethVaultTokenMetadata.MarshalWithEncoder(ethEnc)
+		err := ethVaultTokenMetadata.MarshalWithEncoder(ethEnc)
+		require.NoError(t, err)
 
 		usdtVaultBz := new(bytes.Buffer)
 		usdcEnc := bin.NewBinEncoder(usdtVaultBz)
 		usdtTokenVaultMetadata := token.Account{
 			Amount: 3 * (1e6),
 		}
-		usdtTokenVaultMetadata.MarshalWithEncoder(usdcEnc)
+		err = usdtTokenVaultMetadata.MarshalWithEncoder(usdcEnc)
+		require.NoError(t, err)
 
 		ethUsdtAMMIDBz := new(bytes.Buffer)
 		ethUsdtAMMIDEnc := bin.NewBinEncoder(ethUsdtAMMIDBz)
@@ -399,7 +401,8 @@ func TestProviderFetch(t *testing.T) {
 				NeedTakePnlPc:   uint64(16e5),
 			},
 		}
-		ethUsdtAMMIDEnc.Encode(&ethUsdtAMMIDMetadata)
+		err = ethUsdtAMMIDEnc.Encode(&ethUsdtAMMIDMetadata)
+		require.NoError(t, err)
 
 		ethUsdtOpenOrdersBz := new(bytes.Buffer)
 		ethUsdtOpenOrdersEnc := bin.NewBinEncoder(ethUsdtOpenOrdersBz)
@@ -407,14 +410,16 @@ func TestProviderFetch(t *testing.T) {
 			NativeBaseTokenTotal:  bin.Uint64(1e17),
 			NativeQuoteTokenTotal: bin.Uint64(0.1e6),
 		}
-		ethUsdtOpenOrdersEnc.Encode(&ethUsdtOpenOrdersMetadata)
+		err = ethUsdtOpenOrdersEnc.Encode(&ethUsdtOpenOrdersMetadata)
+		require.NoError(t, err)
 
 		solVaultBz := new(bytes.Buffer)
 		solEnc := bin.NewBinEncoder(solVaultBz)
 		solTokenVaultMetadata := token.Account{
 			Amount: 1e9,
 		}
-		solTokenVaultMetadata.MarshalWithEncoder(solEnc)
+		err = solTokenVaultMetadata.MarshalWithEncoder(solEnc)
+		require.NoError(t, err)
 
 		client.On("GetMultipleAccountsWithOpts", mock.Anything, []solana.PublicKey{
 			btcVaultPk, usdcVaultPk, usdcBtcAMMIDPk, usdcBtcOpenOrdersPk,

--- a/providers/base/config_test.go
+++ b/providers/base/config_test.go
@@ -44,7 +44,7 @@ func TestConfigUpdater(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			provider.Start(ctx)
+			_ = provider.Start(ctx)
 		}()
 
 		// The initial IDs should be the same as the provider's IDs.
@@ -92,7 +92,7 @@ func TestConfigUpdater(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			provider.Start(ctx)
+			_ = provider.Start(ctx)
 		}()
 
 		// The initial IDs should be the same as the provider's IDs.
@@ -142,7 +142,7 @@ func TestConfigUpdater(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			provider.Start(ctx)
+			_ = provider.Start(ctx)
 		}()
 
 		// The initial API handler should be the same as the provider's API handler.
@@ -205,7 +205,7 @@ func TestConfigUpdater(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			provider.Start(ctx)
+			_ = provider.Start(ctx)
 		}()
 
 		// The initial WebSocket handler should be the same as the provider's WebSocket handler.

--- a/providers/base/provider_test.go
+++ b/providers/base/provider_test.go
@@ -610,7 +610,7 @@ func TestWebSocketProvider(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*4)
 			defer cancel()
 
-			provider.Start(ctx)
+			_ = provider.Start(ctx)
 
 			data := provider.GetData()
 			for cp, price := range tc.expectedPrices {

--- a/providers/base/websocket/handlers/ws_query_handler_test.go
+++ b/providers/base/websocket/handlers/ws_query_handler_test.go
@@ -806,7 +806,8 @@ func TestWebSocketQueryHandler(t *testing.T) {
 			responseCh := make(chan providertypes.GetResponse[slinkytypes.CurrencyPair, *big.Int], 20)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			handler.Start(ctx, tc.ids, responseCh)
+			err = handler.Start(ctx, tc.ids, responseCh)
+			require.NoError(t, err)
 			cancel()
 			close(responseCh)
 

--- a/service/servers/oracle/server.go
+++ b/service/servers/oracle/server.go
@@ -59,8 +59,11 @@ func NewOracleServer(o oracle.Oracle, logger *zap.Logger) *OracleServer {
 		// if the server has been started, close it
 		if os.httpSrv != nil {
 			ctx, cf := context.WithTimeout(context.Background(), DefaultServerShutdownTimeout)
-			os.httpSrv.Shutdown(ctx) // close HTTP server backing GRPC-gateway
-			os.grpcSrv.Stop()        // close GRPC server serving listeners that have been routed to GRPC server
+			err := os.httpSrv.Shutdown(ctx)
+			if err != nil {
+				os.logger.Error(fmt.Sprintf("error shutting down http server: %v", err))
+			} // close HTTP server backing GRPC-gateway
+			os.grpcSrv.Stop() // close GRPC server serving listeners that have been routed to GRPC server
 			cf()
 		}
 	})

--- a/service/servers/oracle/server_test.go
+++ b/service/servers/oracle/server_test.go
@@ -72,7 +72,10 @@ func (s *ServerTestSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
 	// start server + client w/ context
-	go s.srv.StartServer(s.ctx, localhost, port)
+	go func() {
+		err := s.srv.StartServer(s.ctx, localhost, port)
+		s.Require().NoError(err)
+	}()
 
 	dialCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/tests/simapp/export.go
+++ b/tests/simapp/export.go
@@ -73,7 +73,7 @@ func (app *SimApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []
 
 	/* Handle fee distribution state. */
 	// withdraw all validator commission
-	app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+	err := app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
 		valAddress, err := sdk.ValAddressFromBech32(val.GetOperator())
 		if err != nil {
 			return true
@@ -81,6 +81,9 @@ func (app *SimApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []
 		_, _ = app.DistrKeeper.WithdrawValidatorCommission(ctx, valAddress)
 		return false
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	// withdraw all delegator rewards
 	dels, err := app.StakingKeeper.GetAllDelegations(ctx)
@@ -109,7 +112,7 @@ func (app *SimApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []
 	ctx = ctx.WithBlockHeight(0)
 
 	// reinitialize all validators
-	app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+	err = app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
 		valAddress, err := sdk.ValAddressFromBech32(val.GetOperator())
 		if err != nil {
 			panic(err)
@@ -133,6 +136,9 @@ func (app *SimApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []
 		}
 		return false
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	// reinitialize all delegations
 	for _, del := range dels {
@@ -159,22 +165,34 @@ func (app *SimApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []
 	/* Handle staking state. */
 
 	// iterate through redelegations, reset creation height
-	app.StakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
+	err = app.StakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
 		for i := range red.Entries {
 			red.Entries[i].CreationHeight = 0
 		}
-		app.StakingKeeper.SetRedelegation(ctx, red)
+		err := app.StakingKeeper.SetRedelegation(ctx, red)
+		if err != nil {
+			panic(err)
+		}
 		return false
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	// iterate through unbonding delegations, reset creation height
-	app.StakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
+	err = app.StakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
 		for i := range ubd.Entries {
 			ubd.Entries[i].CreationHeight = 0
 		}
-		app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
+		err := app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
+		if err != nil {
+			panic(err)
+		}
 		return false
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	// Iterate through validators by power descending, reset bond heights, and
 	// update bond intra-tx counters.
@@ -194,7 +212,10 @@ func (app *SimApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []
 			validator.Jailed = true
 		}
 
-		app.StakingKeeper.SetValidator(ctx, validator)
+		err = app.StakingKeeper.SetValidator(ctx, validator)
+		if err != nil {
+			panic(err)
+		}
 		counter++
 	}
 
@@ -211,12 +232,18 @@ func (app *SimApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []
 	/* Handle slashing state. */
 
 	// reset start height on signing infos
-	app.SlashingKeeper.IterateValidatorSigningInfos(
+	err = app.SlashingKeeper.IterateValidatorSigningInfos(
 		ctx,
 		func(addr sdk.ConsAddress, info slashingtypes.ValidatorSigningInfo) (stop bool) {
 			info.StartHeight = 0
-			app.SlashingKeeper.SetValidatorSigningInfo(ctx, addr, info)
+			err := app.SlashingKeeper.SetValidatorSigningInfo(ctx, addr, info)
+			if err != nil {
+				panic(err)
+			}
 			return false
 		},
 	)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -279,9 +279,12 @@ func (k *Keeper) GetAllCurrencyPairs(ctx sdk.Context) []slinkytypes.CurrencyPair
 	cps := make([]slinkytypes.CurrencyPair, 0)
 
 	// aggregate CurrencyPairs stored under KeyPrefixNonce
-	k.IterateCurrencyPairs(ctx, func(cp slinkytypes.CurrencyPair, _ types.CurrencyPairState) {
+	err := k.IterateCurrencyPairs(ctx, func(cp slinkytypes.CurrencyPair, _ types.CurrencyPairState) {
 		cps = append(cps, cp)
 	})
+	if err != nil {
+		return nil
+	}
 
 	return cps
 }
@@ -294,9 +297,12 @@ func (k *Keeper) GetCurrencyPairMapping(ctx sdk.Context) (map[uint64]slinkytypes
 	}
 	pairs := make(map[uint64]slinkytypes.CurrencyPair, numPairs)
 	// aggregate CurrencyPairs stored under KeyPrefixNonce
-	k.IterateCurrencyPairs(ctx, func(cp slinkytypes.CurrencyPair, cps types.CurrencyPairState) {
+	err = k.IterateCurrencyPairs(ctx, func(cp slinkytypes.CurrencyPair, cps types.CurrencyPairState) {
 		pairs[cps.GetId()] = cp
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	return pairs, nil
 }

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -276,7 +276,8 @@ func (s *KeeperTestSuite) TestIDForCurrencyPair() {
 		s.Require().True(ok)
 
 		// remove the currency-pair
-		s.oracleKeeper.RemoveCurrencyPair(s.ctx, cp2)
+		err := s.oracleKeeper.RemoveCurrencyPair(s.ctx, cp2)
+		s.Require().NoError(err)
 
 		// check that the id is no longer in use
 		_, ok = s.oracleKeeper.GetCurrencyPairFromID(s.ctx, unusedID)

--- a/x/sla/keeper/strategy_test.go
+++ b/x/sla/keeper/strategy_test.go
@@ -44,7 +44,8 @@ func (s *KeeperTestSuite) TestExecSLA() {
 		err = s.keeper.SetPriceFeed(s.ctx, priceFeed)
 		s.Require().NoError(err)
 
-		s.keeper.SetSLA(s.ctx, sla)
+		err = s.keeper.SetSLA(s.ctx, sla)
+		s.Require().NoError(err)
 		err = s.keeper.ExecSLA(s.ctx, sla)
 		s.Require().NoError(err)
 	})
@@ -55,14 +56,15 @@ func (s *KeeperTestSuite) TestExecSLA() {
 		priceFeed, err := slatypes.NewPriceFeed(uint(maximumViableWindow), validator, cp, id)
 		s.Require().NoError(err)
 		for i := 0; i < 20; i++ {
-			priceFeed.SetUpdate(slatypes.VoteWithPrice)
+			_ = priceFeed.SetUpdate(slatypes.VoteWithPrice)
 		}
 		err = s.keeper.SetPriceFeed(s.ctx, priceFeed)
 		s.Require().NoError(err)
 
 		s.stakingKeeper.On("GetLastValidatorPower", s.ctx, sdk.ValAddress(validator.Bytes())).Return(int64(0), fmt.Errorf("validator does not exist"))
 
-		s.keeper.SetSLA(s.ctx, sla)
+		err = s.keeper.SetSLA(s.ctx, sla)
+		s.Require().NoError(err)
 		err = s.keeper.ExecSLA(s.ctx, sla)
 		s.Require().NoError(err)
 
@@ -80,7 +82,8 @@ func (s *KeeperTestSuite) TestExecSLA() {
 		err = s.keeper.SetPriceFeed(s.ctx, priceFeed)
 		s.Require().NoError(err)
 
-		s.keeper.SetSLA(s.ctx, sla)
+		err = s.keeper.SetSLA(s.ctx, sla)
+		s.Require().NoError(err)
 		err = s.keeper.ExecSLA(s.ctx, sla)
 		s.Require().NoError(err)
 	})
@@ -91,7 +94,7 @@ func (s *KeeperTestSuite) TestExecSLA() {
 		priceFeed, err := slatypes.NewPriceFeed(uint(maximumViableWindow), validator, cp, id)
 		s.Require().NoError(err)
 		for i := 0; i < 20; i++ {
-			priceFeed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = priceFeed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 		err = s.keeper.SetPriceFeed(s.ctx, priceFeed)
 		s.Require().NoError(err)
@@ -108,7 +111,8 @@ func (s *KeeperTestSuite) TestExecSLA() {
 			expectedSlashFactor,
 		).Return(math.NewInt(10), nil)
 
-		s.keeper.SetSLA(s.ctx, sla)
+		err = s.keeper.SetSLA(s.ctx, sla)
+		s.Require().NoError(err)
 		err = s.keeper.ExecSLA(s.ctx, sla)
 		s.Require().NoError(err)
 	})
@@ -119,17 +123,18 @@ func (s *KeeperTestSuite) TestExecSLA() {
 		priceFeed, err := slatypes.NewPriceFeed(uint(maximumViableWindow), validator, cp, id)
 		s.Require().NoError(err)
 		for i := 0; i < 16; i++ {
-			priceFeed.SetUpdate(slatypes.VoteWithPrice)
+			_ = priceFeed.SetUpdate(slatypes.VoteWithPrice)
 		}
 		for i := 0; i < 4; i++ {
-			priceFeed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = priceFeed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 		err = s.keeper.SetPriceFeed(s.ctx, priceFeed)
 		s.Require().NoError(err)
 
 		s.stakingKeeper.On("GetLastValidatorPower", mock.Anything, sdk.ValAddress(validator)).Return(int64(100), nil)
 
-		s.keeper.SetSLA(s.ctx, sla)
+		err = s.keeper.SetSLA(s.ctx, sla)
+		s.Require().NoError(err)
 		err = s.keeper.ExecSLA(s.ctx, sla)
 		s.Require().NoError(err)
 	})
@@ -140,14 +145,15 @@ func (s *KeeperTestSuite) TestExecSLA() {
 		priceFeed, err := slatypes.NewPriceFeed(uint(maximumViableWindow), validator, cp, id)
 		s.Require().NoError(err)
 		for i := 0; i < 20; i++ {
-			priceFeed.SetUpdate(slatypes.VoteWithPrice)
+			_ = priceFeed.SetUpdate(slatypes.VoteWithPrice)
 		}
 		err = s.keeper.SetPriceFeed(s.ctx, priceFeed)
 		s.Require().NoError(err)
 
 		s.stakingKeeper.On("GetLastValidatorPower", mock.Anything, sdk.ValAddress(validator)).Return(int64(100), nil)
 
-		s.keeper.SetSLA(s.ctx, sla)
+		err = s.keeper.SetSLA(s.ctx, sla)
+		s.Require().NoError(err)
 		err = s.keeper.ExecSLA(s.ctx, sla)
 		s.Require().NoError(err)
 	})
@@ -158,10 +164,10 @@ func (s *KeeperTestSuite) TestExecSLA() {
 		priceFeed, err := slatypes.NewPriceFeed(uint(maximumViableWindow), validator, cp, id)
 		s.Require().NoError(err)
 		for i := 0; i < 5; i++ {
-			priceFeed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = priceFeed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 		for i := 0; i < 5; i++ {
-			priceFeed.SetUpdate(slatypes.VoteWithPrice)
+			_ = priceFeed.SetUpdate(slatypes.VoteWithPrice)
 		}
 		err = s.keeper.SetPriceFeed(s.ctx, priceFeed)
 		s.Require().NoError(err)
@@ -179,7 +185,8 @@ func (s *KeeperTestSuite) TestExecSLA() {
 			expectedSlashFactor,
 		).Return(math.NewInt(10), nil)
 
-		s.keeper.SetSLA(s.ctx, sla)
+		err = s.keeper.SetSLA(s.ctx, sla)
+		s.Require().NoError(err)
 		err = s.keeper.ExecSLA(s.ctx, sla)
 		s.Require().NoError(err)
 	})
@@ -190,10 +197,10 @@ func (s *KeeperTestSuite) TestExecSLA() {
 		priceFeed, err := slatypes.NewPriceFeed(uint(maximumViableWindow), validator, cp, id)
 		s.Require().NoError(err)
 		for i := 0; i < 10; i++ {
-			priceFeed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = priceFeed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 		for i := 0; i < 10; i++ {
-			priceFeed.SetUpdate(slatypes.VoteWithPrice)
+			_ = priceFeed.SetUpdate(slatypes.VoteWithPrice)
 		}
 		err = s.keeper.SetPriceFeed(s.ctx, priceFeed)
 		s.Require().NoError(err)
@@ -211,7 +218,8 @@ func (s *KeeperTestSuite) TestExecSLA() {
 			expectedSlashFactor,
 		).Return(math.NewInt(10), nil)
 
-		s.keeper.SetSLA(s.ctx, sla)
+		err = s.keeper.SetSLA(s.ctx, sla)
+		s.Require().NoError(err)
 		err = s.keeper.ExecSLA(s.ctx, sla)
 		s.Require().NoError(err)
 	})
@@ -286,7 +294,7 @@ func (s *KeeperTestSuite) TestEnforceSLA() {
 
 	s.Run("100% uptime with minimum number of blocks", func() {
 		for i := 0; i < 10; i++ {
-			feed.SetUpdate(slatypes.VoteWithPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithPrice)
 		}
 
 		s.stakingKeeper.On(
@@ -301,7 +309,7 @@ func (s *KeeperTestSuite) TestEnforceSLA() {
 
 	s.Run("100% uptime with maximum number of blocks", func() {
 		for i := 0; i < 20; i++ {
-			feed.SetUpdate(slatypes.VoteWithPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithPrice)
 		}
 
 		s.stakingKeeper.On(
@@ -324,11 +332,11 @@ func (s *KeeperTestSuite) TestEnforceSLA() {
 		s.Require().NoError(err)
 
 		for i := 0; i < 5; i++ {
-			feed.SetUpdate(slatypes.VoteWithPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithPrice)
 		}
 
 		for i := 0; i < 5; i++ {
-			feed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 
 		s.stakingKeeper.On(
@@ -363,11 +371,11 @@ func (s *KeeperTestSuite) TestEnforceSLA() {
 		s.Require().NoError(err)
 
 		for i := 0; i < 10; i++ {
-			feed.SetUpdate(slatypes.VoteWithPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithPrice)
 		}
 
 		for i := 0; i < 10; i++ {
-			feed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 
 		s.stakingKeeper.On(
@@ -402,7 +410,7 @@ func (s *KeeperTestSuite) TestEnforceSLA() {
 		s.Require().NoError(err)
 
 		for i := 0; i < 10; i++ {
-			feed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 
 		s.stakingKeeper.On(
@@ -436,7 +444,7 @@ func (s *KeeperTestSuite) TestEnforceSLA() {
 		s.Require().NoError(err)
 
 		for i := 0; i < 20; i++ {
-			feed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 
 		s.stakingKeeper.On(
@@ -470,11 +478,11 @@ func (s *KeeperTestSuite) TestEnforceSLA() {
 		s.Require().NoError(err)
 
 		for i := 0; i < 15; i++ {
-			feed.SetUpdate(slatypes.VoteWithPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithPrice)
 		}
 
 		for i := 0; i < 5; i++ {
-			feed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 
 		s.stakingKeeper.On(
@@ -509,11 +517,11 @@ func (s *KeeperTestSuite) TestEnforceSLA() {
 		s.Require().NoError(err)
 
 		for i := 0; i < 20; i++ {
-			feed.SetUpdate(slatypes.VoteWithPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithPrice)
 		}
 
 		for i := 0; i < 5; i++ {
-			feed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 
 		s.stakingKeeper.On(
@@ -548,11 +556,11 @@ func (s *KeeperTestSuite) TestEnforceSLA() {
 		s.Require().NoError(err)
 
 		for i := 0; i < 50; i++ {
-			feed.SetUpdate(slatypes.VoteWithPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithPrice)
 		}
 
 		for i := 0; i < 5; i++ {
-			feed.SetUpdate(slatypes.VoteWithoutPrice)
+			_ = feed.SetUpdate(slatypes.VoteWithoutPrice)
 		}
 
 		s.stakingKeeper.On(


### PR DESCRIPTION
integrating `errcheck`, we aim to enforce best practices for error handling, improving code reliability and maintainability.