### PR TITLE
chore: Remove testapp from install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ stop-sidecar-dev:
 
 install: tidy
 	@go install -ldflags="$(BUILD_TAGS)" -mod=readonly ./cmd/slinky
-	@go install -mod=readonly $(BUILD_FLAGS) ./tests/simapp/slinkyd
 
 .PHONY: build install run-oracle-client start-all-dev stop-all-dev
 


### PR DESCRIPTION
Removes the testapp from the install directive. The install should just install the binary, and we have and use a separate make target for building and installing the test app binary.


BLO-1524