### PR TITLE
ci: dont run CI test/build for docs PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build Slinky docker images
 on:
   push:
+    paths-ignore:
+      - docs/**
     branches:
       - main
     tags:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,8 @@
 name: E2E tests
 on: 
   pull_request:
+    paths-ignore:
+      - docs/**
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths-ignore:
       - tests/**
+      - docs/**
 
 permissions:
   contents: read


### PR DESCRIPTION
changes our ci to not run code test/builds when the PR only affects docs