### PR TITLE
docs: update mint.json with "isWhiteLabeled"

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -20,6 +20,7 @@
     "og:site_name": "Connect Docs",
     "twitter:site": "@skipprotocol"
   },
+  "isWhiteLabeled": true,
   "topbarLinks": [
     {
       "name": "Skip:Go",


### PR DESCRIPTION
adds `isWhiteLabeled` to `mint.json` which removes the "Powered by Mintlify" text at the bottom of the page.