### PR TITLE
fix: clearer err msg when overriding an unknown provider type

### DIFF
--- a/cmd/slinky/config/config.go
+++ b/cmd/slinky/config/config.go
@@ -133,10 +133,16 @@ func ReadOracleConfigWithOverrides(path string, marketMapProvider string) (confi
 // oracleConfigFromViper unmarshals an oracle config from viper, validates it, and returns it.
 func oracleConfigFromViper() (config.OracleConfig, error) {
 	var cfg config.OracleConfig
+	unmarshalMetadata := mapstructure.Metadata{}
 	if err := viper.Unmarshal(&cfg, func(c *mapstructure.DecoderConfig) {
 		c.ErrorUnused = true
+		c.Metadata = &unmarshalMetadata
 	}); err != nil {
 		return config.OracleConfig{}, err
+	}
+
+	if len(unmarshalMetadata.Unset) > 0 {
+		return config.OracleConfig{}, fmt.Errorf("overridden key %s does not correspond to a known provider", unmarshalMetadata.Unset[0])
 	}
 
 	// for each api-provider, we'll have to manually fill the endpoints

--- a/cmd/slinky/config/config.go
+++ b/cmd/slinky/config/config.go
@@ -141,12 +141,15 @@ func oracleConfigFromViper() (config.OracleConfig, error) {
 		return config.OracleConfig{}, err
 	}
 
-	if len(unmarshalMetadata.Unset) > 0 {
-		return config.OracleConfig{}, fmt.Errorf("overridden key %s does not correspond to a known provider", unmarshalMetadata.Unset[0])
-	}
-
 	// for each api-provider, we'll have to manually fill the endpoints
 	for _, provider := range cfg.Providers {
+		// if a provider was not unmarshaled correctly, surface that error
+		if provider.Name == "" {
+			if len(unmarshalMetadata.Unset) > 0 {
+				return config.OracleConfig{}, fmt.Errorf("overridden key %s does not correspond to a known provider", unmarshalMetadata.Unset[0])
+			}
+		}
+
 		// Update API endpoints
 		for i, endpoint := range provider.API.Endpoints {
 			provider.API.Endpoints[i], _ = updateEndpointFromEnvironment(endpoint, provider.Name, i, "api")

--- a/cmd/slinky/config/config_test.go
+++ b/cmd/slinky/config/config_test.go
@@ -393,7 +393,7 @@ func TestReadOracleConfigWithOverrides(t *testing.T) {
 		tmpfile.Write([]byte(overrides))
 
 		_, err = cmdconfig.ReadOracleConfigWithOverrides(tmpfile.Name(), marketmap.Name)
-		require.Error(t, err)
+		require.ErrorContains(t, err, "overridden key")
 	})
 }
 

--- a/cmd/slinky/config/config_test.go
+++ b/cmd/slinky/config/config_test.go
@@ -364,7 +364,7 @@ func TestReadOracleConfigWithOverrides(t *testing.T) {
 				"prometheusServerAddress": "%s"
 			},
 			"providers": {
-				"aydium_api": {
+				"doesNotExist": {
 					"api": {
 						"endpoints": [
 							{


### PR DESCRIPTION
Guards against typos like this in the oracle config:
```
{
  "providers": {
    "aydium_api": {
      "api": {
        "endpoints": [
            { ... }
        ]
      }
    }
  }
}
```

... errors now with `Error: failed to get oracle config: overridden key Providers[aydium_api].API.Timeout does not correspond to a known provider` instead of the vaguer `name cannot be empty`