### PR TITLE
chore: Follow redirects in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,7 +10,7 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
 # Fetch the latest release information
 echo "Fetching latest release information..."
-RELEASE_INFO=$(curl -s ${SLINKY_RELEASES_URL})
+RELEASE_INFO=$(curl -Ls ${SLINKY_RELEASES_URL})
 VERSION=$(echo ${RELEASE_INFO} | grep -o '"tag_name": "v[^"]*' | cut -d'"' -f4)
 VERSION=${VERSION#v}  # Remove the 'v' prefix
 


### PR DESCRIPTION
The install script is broken since we renamed the repo. Need to have curl follow redirects and it works again.

Will plan on updating the install script fully once connect v2 is released.