### PR TITLE
chore: Fix user permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ test-cover: tidy
 	@sed -i'.bak' -e '/.pb.gw.go/d' $(COVER_FILE)
 	@sed -i'.bak' -e '/mocks/d' $(COVER_FILE)
 
-.PHONY: test test-e2e test-petri-integ
+.PHONY: test test-integration test-petri-integ
 
 ###############################################################################
 ###                                Protobuf                                 ###

--- a/contrib/images/connect.sidecar.prod.Dockerfile
+++ b/contrib/images/connect.sidecar.prod.Dockerfile
@@ -13,8 +13,6 @@ RUN make build
 FROM gcr.io/distroless/base-debian11:debug
 EXPOSE 8080 8002
 
-USER connect:connect
-
 COPY --from=builder /src/connect/build/* /usr/local/bin/
 
 WORKDIR /usr/local/bin/

--- a/contrib/images/slinky.sidecar.prod.Dockerfile
+++ b/contrib/images/slinky.sidecar.prod.Dockerfile
@@ -13,8 +13,6 @@ RUN make build
 FROM gcr.io/distroless/base-debian11:debug
 EXPOSE 8080 8002
 
-USER connect:connect
-
 COPY --from=builder /src/connect/build/* /usr/local/bin/
 COPY --from=builder /src/connect/scripts/deprecated-exec.sh /usr/local/bin/
 


### PR DESCRIPTION
Setting a new user in this way ends up with issues when using an entrypoint command since no entries exist in the corresponding etc/ files. 

I tried setting the `nobody` user which is built into distroless images, but then mounting files in to use as a config becomes an issue. It seems pretty low stakes to give users root inside the distroless container, so I'm just reverting for now.