### PR TITLE
fix: put v2 at the end of the module url for connect's tests

### DIFF
--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -1,4 +1,4 @@
-module github.com/skip-mev/connect/v2/tests/integration
+module github.com/skip-mev/connect/tests/integration/v2
 
 replace (
 	github.com/ChainSafe/go-schnorrkel => github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d

--- a/tests/integration/slinky_integration_test.go
+++ b/tests/integration/slinky_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/skip-mev/connect/v2/tests/integration"
+	"github.com/skip-mev/connect/tests/integration/v2"
 	marketmapmodule "github.com/skip-mev/connect/v2/x/marketmap"
 	"github.com/skip-mev/connect/v2/x/oracle"
 )


### PR DESCRIPTION
When there are multiple modules in the same repository, Go has a strong preference for versioning each of them independently.

So, I think that this will allow users to import the correct version of the connect tests.

Here's an example of what I'm trying to address here:

[* https://github.com/cosmos/ibc-go/blob/main/modules/capability/go.mod
](https://github.com/cosmos/ibc-go/blob/46856701a5e3e5ad6f7605c4ad7d576a67cc693d/modules/capability/go.mod#L1)


So even though ibc-go is at v8, we can see that the capability module, which shares commits from ibc-go/v8 drops the /v8 part in its import url.

I think it is mainly just golang being odd, and that this will resolve some issues when external users and developers try to import connect's tests.


