### PR TITLE
fix: flaky oracle test

### DIFF
--- a/service/servers/oracle/server_test.go
+++ b/service/servers/oracle/server_test.go
@@ -58,7 +58,7 @@ func (s *ServerTestSuite) SetupTest() {
 	s.srv = server.NewOracleServer(s.mockOracle, logger)
 
 	// listen on a random port and extract that port number
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", localhost+":0")
 	s.Require().NoError(err)
 	defer l.Close()
 	s.port = strconv.Itoa(l.Addr().(*net.TCPAddr).Port)

--- a/service/servers/oracle/server_test.go
+++ b/service/servers/oracle/server_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"net"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -27,7 +29,6 @@ import (
 
 const (
 	localhost     = "localhost"
-	port          = "8080"
 	timeout       = 1 * time.Second
 	delay         = 20 * time.Second
 	grpcErrPrefix = "rpc error: code = Unknown desc = "
@@ -42,6 +43,7 @@ type ServerTestSuite struct {
 	httpClient *http.Client
 	ctx        context.Context
 	cancel     context.CancelFunc
+	port       string
 }
 
 func TestServerTestSuite(t *testing.T) {
@@ -55,10 +57,15 @@ func (s *ServerTestSuite) SetupTest() {
 	s.mockOracle = mocks.NewOracle(s.T())
 	s.srv = server.NewOracleServer(s.mockOracle, logger)
 
-	var err error
+	// listen on a random port and extract that port number
+	l, err := net.Listen("tcp", ":0")
+	s.Require().NoError(err)
+	defer l.Close()
+	s.port = strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
+
 	s.client, err = client.NewClient(
 		log.NewTestLogger(s.T()),
-		localhost+":"+port,
+		localhost+":"+s.port,
 		timeout,
 		metrics.NewNopMetrics(),
 		client.WithBlockingDial(), // block on dialing the server
@@ -72,7 +79,7 @@ func (s *ServerTestSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
 	// start server + client w/ context
-	go s.srv.StartServer(s.ctx, localhost, port)
+	go s.srv.StartServer(s.ctx, "0.0.0.0", s.port)
 
 	dialCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -157,7 +164,7 @@ func (s *ServerTestSuite) TestOracleServerPrices() {
 	s.Require().Equal(resp.Timestamp, ts.UTC())
 
 	// call from http client
-	httpResp, err := s.httpClient.Get(fmt.Sprintf("http://%s:%s/slinky/oracle/v1/prices", localhost, port))
+	httpResp, err := s.httpClient.Get(fmt.Sprintf("http://%s:%s/slinky/oracle/v1/prices", localhost, s.port))
 	s.Require().NoError(err)
 
 	// check response


### PR DESCRIPTION
Dynamically grabs a port instead of 8080 every time and listens on 0.0.0.0 during this test. Not sure if it was because tests were being run concurrently or what but this could fix the flakiness.