### PR TITLE
fix: add expected mock to TestOracleMarketMap

### DIFF
--- a/service/servers/oracle/server_test.go
+++ b/service/servers/oracle/server_test.go
@@ -180,6 +180,7 @@ func (s *ServerTestSuite) TestOracleServerPrices() {
 }
 
 func (s *ServerTestSuite) TestOracleMarketMap() {
+	s.mockOracle.On("IsRunning").Return(true)
 	dummyMarketMap := mmtypes.MarketMap{Markets: map[string]mmtypes.Market{
 		"foo": {
 			Ticker: mmtypes.Ticker{
@@ -204,7 +205,6 @@ func (s *ServerTestSuite) TestOracleMarketMap() {
 	expectedJSON, err := dummyMarketMap.Marshal()
 	_ = expectedJSON
 	s.Require().NoError(err)
-	s.mockOracle.On("IsRunning").Return(true)
 	s.mockOracle.On("GetMarketMap", mock.Anything).Return(dummyMarketMap).Once()
 
 	res, err := s.client.MarketMap(context.Background(), &stypes.QueryMarketMapRequest{})

--- a/service/servers/oracle/server_test.go
+++ b/service/servers/oracle/server_test.go
@@ -204,6 +204,7 @@ func (s *ServerTestSuite) TestOracleMarketMap() {
 	expectedJSON, err := dummyMarketMap.Marshal()
 	_ = expectedJSON
 	s.Require().NoError(err)
+	s.mockOracle.On("IsRunning").Return(true)
 	s.mockOracle.On("GetMarketMap", mock.Anything).Return(dummyMarketMap).Once()
 
 	res, err := s.client.MarketMap(context.Background(), &stypes.QueryMarketMapRequest{})


### PR DESCRIPTION
This call was expected but was not mocked, causing this test to fail https://github.com/skip-mev/connect/actions/runs/10857174341/job/30133166035