### PR TITLE
docs: fix dead link for oracle config

### DIFF
--- a/docs/validators/configuration.mdx
+++ b/docs/validators/configuration.mdx
@@ -14,8 +14,8 @@ Connect can be configured by both flags and environment variables.
 
 The following values are read via environment variables:
 
-| Key                                             | Default          | Description                                                                                                                                        |
-|-------------------------------------------------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key                                              | Default          | Description                                                                                                                                        |
+|--------------------------------------------------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `CONNECT_CONFIG_HOST`                            | `"0.0.0.0"`      | The address Connect will serve requests from. WARNING: changing this value requires updating the `oracle_address` in the `app.toml` configuration. |
 | `CONNECT_CONFIG_PORT`                            | `"8080"`         | The port Connect will serve requests from. WARNING: changing this value requires updating the `oracle_address` in the `app.toml` configuration.    |
 | `CONNECT_CONFIG_METRICS_ENABLED`                 | `"true"`         | Enables prometheus metrics.                                                                                                                        |

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -8,9 +8,7 @@ Responsibilities of the Oracle:
 
 ## Configuration
 
-At a high level the oracle is configured with a `oracle.json` file that contains all providers that need to be 
-instantiated. To read more about the configuration of `oracle.json`, please refer to the [oracle configuration 
-documentation](../docs/validators/configuration.mdx).
+At a high level the oracle is configured with a `oracle.json` file that contains all providers that need to be instantiated. To read more about the configuration of `oracle.json`, please refer to the [oracle configuration documentation](../docs/validators/configuration.mdx).
 
 Each provider is instantiated using the `PriceAPIQueryHandlerFactory`, `PriceWebSocketQueryHandlerFactory`, and `MarketMapFactory` factory functions. Think of these as the constructors for the providers. 
 

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -8,7 +8,9 @@ Responsibilities of the Oracle:
 
 ## Configuration
 
-At a high level the oracle is configured with a `oracle.json` file that contains all providers that need to be instantiated. To read more about the configuration of `oracle.json`, please refer to the [oracle configuration documentation](config/README.md).
+At a high level the oracle is configured with a `oracle.json` file that contains all providers that need to be 
+instantiated. To read more about the configuration of `oracle.json`, please refer to the [oracle configuration 
+documentation](../docs/validators/configuration.mdx).
 
 Each provider is instantiated using the `PriceAPIQueryHandlerFactory`, `PriceWebSocketQueryHandlerFactory`, and `MarketMapFactory` factory functions. Think of these as the constructors for the providers. 
 


### PR DESCRIPTION
Reroute a dead reference in a README to our actual docs that describes configuration.

Closes https://github.com/skip-mev/connect/issues/761
Closes CON-1754