### PR TITLE
chore: print filename for debug purposes in genesis script

### DIFF
--- a/scripts/genesis.go
+++ b/scripts/genesis.go
@@ -38,6 +38,8 @@ func main() {
 			panic("market map config path (market-cfg-path) cannot be empty")
 		}
 
+		fmt.Printf("reading in market map file: %s\n", *marketFile)
+
 		marketMap, err := mmtypes.ReadMarketMapFromFile(*marketFile)
 		if err != nil {
 			fmt.Fprintf(flag.CommandLine.Output(), "failed to read market map from file: %s\n", err)


### PR DESCRIPTION
Just will be a nice thing to have in the future if our deployments are ever having issues reading in files