### PR TITLE
fix: ics provider version

### DIFF
--- a/tests/integration/consumer.go
+++ b/tests/integration/consumer.go
@@ -17,7 +17,7 @@ import (
 var (
 	providerChainID       = "provider-1"
 	providerNumValidators = 4
-	providerVersion       = "v5.0.0-rc0"
+	providerVersion       = "v6.0.0"
 )
 
 // CCVChainConstructor is a constructor for the CCV chain


### PR DESCRIPTION
When I bumped our ICS version to v6, I forgot to bump this constant string which is the image version that is fetched.

Now using v6.0.0 which is a version family needed and the latest supported by strangeloves image [registry](https://github.com/strangelove-ventures/heighliner/pkgs/container/heighliner%2Fics)

After merge I will make a `v2.1.1` release to unblock ICS v6 team who may be using our e2e test suite