### PR TITLE
chore: change use and short text for `connect` binary

### DIFF
--- a/cmd/connect/main.go
+++ b/cmd/connect/main.go
@@ -37,8 +37,8 @@ import (
 
 var (
 	rootCmd = &cobra.Command{
-		Use:   "oracle",
-		Short: "Run the connect oracle server.",
+		Use:   "connect",
+		Short: "Run the connect oracle.",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runOracle()


### PR DESCRIPTION
before:

```shell
connect blah
Error: unknown command "blah" for "oracle"
Usage:
  oracle [flags]
  oracle [command]
```

after:

```shell
connect blah
Error: unknown command "blah" for "connect"
Usage:
  connect [flags]
  connect [command]
```