### PR TITLE
fix: remove unnecessary block from websocket subtask creator

### DIFF
--- a/providers/base/fetch.go
+++ b/providers/base/fetch.go
@@ -86,7 +86,6 @@ func (p *Provider[K, V]) startMultiplexWebsocket(ctx context.Context) error {
 	if maxSubsPerConn > 0 {
 		// case where we will split ID's across sub handlers
 		numSubHandlers := int(math.Ceil(float64(len(ids)) / float64(maxSubsPerConn)))
-		p.logger.Debug("setting number of web socket handlers for provider", zap.Int("sub_handlers", numSubHandlers))
 		wg.SetLimit(numSubHandlers)
 		subTasks = slices.Chunk(ids, maxSubsPerConn)
 	} else {
@@ -97,13 +96,6 @@ func (p *Provider[K, V]) startMultiplexWebsocket(ctx context.Context) error {
 
 	for _, subIDs := range subTasks {
 		wg.Go(p.startWebSocket(ctx, subIDs))
-		select {
-		case <-time.After(p.wsCfg.HandshakeTimeout):
-			p.logger.Debug("handshake timeout reached")
-		case <-ctx.Done():
-			p.logger.Debug("context done")
-			return wg.Wait()
-		}
 	}
 
 	// Wait for all the sub handlers to finish.


### PR DESCRIPTION
changes:
- using slices.Chunk instead of manually constructing chunked slices
- removed the block on spinning up subtasks. for some reason, we would `select` block on an arbitrary timeout period, even though it wouldn't actually do anything. it was just a random block. 
- remove a debug log while im here because its noisy.


i ran this version of connect with through the validator and had no problems.