### PR TITLE
docs: Addressing Typos in Architecture and Metrics Sections

### DIFF
--- a/docs/learn/architecture.mdx
+++ b/docs/learn/architecture.mdx
@@ -28,7 +28,7 @@ The `ExtendVote` and `VerifyVote` methods of ABCI++ are where a price is first q
 
 During `PrepareProposal`, the vote extensions from the previous block are aggregated by the block proposer into their block proposal, after various checks are run on them.
 
-- Connect ensures that the set of vote extensions comprise the required minimum stake required for a price update (default of 2/3).
+- Connect ensures that the set of vote extensions comprise the minimum stake required for a price update (default of 2/3).
 - It also ensures that the vote extensions are valid and can be understood by the application.
 - Finally, it encodes the vote extensions and injects them into the top of the block proposal as a pseudo-transaction ignored by the chain.
 

--- a/docs/metrics/application-reference.mdx
+++ b/docs/metrics/application-reference.mdx
@@ -10,7 +10,7 @@ By default, Cosmos SDK application expose metrics on port `26660`. These metrics
 
 ## Oracle Client Connection Metrics
 
-- **oracle_response_latency:** Histogram that measures the time in nanoseconds between request/response of from the Application to Oracle.
+- **oracle_response_latency:** Histogram that measures the time in nanoseconds between request/response from the Application to Oracle.
 - **oracle_responses:** Counter that measures the number of oracle responses.
 
 ## ABCI Metrics


### PR DESCRIPTION
This pull request focuses on enhancing the documentation by correcting typographical and grammatical errors found in key sections.

## Summary of Updates  

### 1. **`architecture.mdx`**  
- Improved the explanation of vote extension requirements by removing redundancy.  
  - Previous: "comprise the required minimum stake required for a price update."  
  - Revised: "comprise the minimum stake required for a price update."  

### 2. **`application-reference.mdx`**  
- Resolved a grammatical issue in the `oracle_response_latency` description.  
  - Previous: "time in nanoseconds between request/response of from the Application to Oracle."  
  - Revised: "time in nanoseconds between request/response from the Application to Oracle."  
