### PR TITLE
fix typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ After a few minutes, run the following commands to see the prices written to the
 $ docker exec -it compose-blockchain-1 bash
 
 # query the price of bitcoin in USD on the node
-$ (compose-blockchain-1) ./build/connectd q oracle price BTC USD
+$ (compose-blockchain-1) ./build/connected q oracle price BTC USD
 ```
 
 Result:


### PR DESCRIPTION
# Fix Typo in README.md

## Description

This pull request corrects a typo in the `README.md` file. The command example for querying Bitcoin's price was mistakenly written as `./build/connected` instead of the correct `./build/connectd`.


