### PR TITLE
Corrected typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ After a few minutes, run the following commands to see the prices written to the
 $ docker exec -it compose-blockchain-1 bash
 
 # query the price of bitcoin in USD on the node
-$ (compose-blockchain-1) ./build/connectd q oracle price BTC USD
+$ (compose-blockchain-1) ./build/connected q oracle price BTC USD
 ```
 
 Result:

--- a/tests/integration/connect_suite.go
+++ b/tests/integration/connect_suite.go
@@ -403,7 +403,7 @@ func (s *ConnectOracleIntegrationSuite) TestOracleModule() {
 	s.Run("remove a non existent market", func() {
 		nonexistentCP := connecttypes.NewCurrencyPair("NON", "EXIST")
 
-		// check removed doesnt exist
+		// check removed doesn't, does not exist
 		_, err := QueryMarket(s.chain, nonexistentCP)
 		s.Require().Error(err)
 

--- a/x/marketmap/README.md
+++ b/x/marketmap/README.md
@@ -304,7 +304,7 @@ The `MarketMap` endpoint queries the full state of the market map as well as ass
 Example:
 
 ```shell
-  connectd q marketmap market-map
+  connected q marketmap market-map
 ```
 
 #### LastUpdated
@@ -316,7 +316,7 @@ must be updated using the heavier `MarketMap` query.
 Example:
 
 ```shell
-  connectd q marketmap last-updated
+  connected q marketmap last-updated
 ```
 
 #### Params
@@ -326,5 +326,5 @@ The params query allows users to query values set as marketmap parameters.
 Example:
 
 ```shell
-  connectd q marketmap params
+  connected q marketmap params
 ```


### PR DESCRIPTION
Changes made in:

- /README.md ("connectd" → "connected")

- /x/marketmap/README.md ("connectd" → "connected")

- /x/marketmap/README.md ("connectd" → "connected")

- /tests/integration/connect_suite.go ("doesnt" → "doesn't, does not")
