### PR TITLE
chore: refactor to simplify version extraction

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 # Fetch the latest release information
 echo "Fetching latest release information..."
 RELEASE_INFO=$(curl -Ls ${CONNECT_RELEASES_URL})
-VERSION=$(echo "${RELEASE_INFO}" | grep -o '"tag_name": "v[^"]*' | cut -d'"' -f4)
+VERSION=$(echo "${RELEASE_INFO}" | jq -r '.tag_name' | sed 's/^v//')
 VERSION=${VERSION#v}  # Remove the 'v' prefix
 
 # Map architecture to release file name


### PR DESCRIPTION
Fixed the version extraction logic by removing unnecessary `echo` and `cut` commands. Replaced them with `jq` to streamline the process and improve speed. Now, the version is directly extracted using `jq`, followed by a `sed` to remove the 'v' prefix. This makes the code cleaner and more efficient, assuming `jq` is available.